### PR TITLE
Refactor wind system with spatial hash and directional effects

### DIFF
--- a/src/game/TurbulenceParticle.ts
+++ b/src/game/TurbulenceParticle.ts
@@ -1,0 +1,95 @@
+import BaseEntity from "../core/entity/BaseEntity";
+import { V, V2d } from "../core/Vector";
+import type { Wind } from "./Wind";
+import { WindModifier } from "./WindModifier";
+
+// Turbulence particle configuration
+const TURBULENCE_STRENGTH = 10; // Magnitude of chaotic velocity contribution
+const TURBULENCE_RADIUS = 8; // Influence radius of each particle
+const TURBULENCE_LIFETIME = 1.5; // Particle lifespan in seconds
+
+/**
+ * A turbulence particle that drifts with the wind and creates chaotic
+ * disturbances in the wind field. Spawned by stalled sail segments.
+ */
+export class TurbulenceParticle extends BaseEntity implements WindModifier {
+  tags = ["windModifier", "turbulence"];
+
+  private age: number = 0;
+  private intensity: number = 1.0;
+  private seed: number;
+
+  constructor(
+    private position: V2d,
+    private initialVelocity: V2d
+  ) {
+    super();
+    // Use position hash as seed for deterministic chaos
+    this.seed = Math.abs(
+      Math.floor(position.x * 1000 + position.y * 7919)
+    );
+  }
+
+  onTick(dt: number) {
+    const wind = this.game?.entities.getById("wind") as Wind | undefined;
+    if (!wind) return;
+
+    // Drift with the local wind
+    const windVel = wind.getBaseVelocityAtPoint(this.position);
+    this.position = this.position.add(windVel.mul(dt));
+
+    // Age and decay intensity
+    this.age += dt;
+    this.intensity = Math.max(0, 1 - this.age / TURBULENCE_LIFETIME);
+
+    // Self-destruct when faded
+    if (this.age >= TURBULENCE_LIFETIME) {
+      this.destroy();
+    }
+  }
+
+  // WindModifier interface
+
+  getWindModifierPosition(): V2d {
+    return this.position;
+  }
+
+  getWindModifierInfluenceRadius(): number {
+    return TURBULENCE_RADIUS;
+  }
+
+  getWindVelocityContribution(queryPoint: V2d): V2d {
+    const toQuery = queryPoint.sub(this.position);
+    const dist = toQuery.magnitude;
+
+    if (dist > TURBULENCE_RADIUS || dist < 1) {
+      return V(0, 0);
+    }
+
+    // Distance falloff
+    const falloff = 1 - dist / TURBULENCE_RADIUS;
+
+    // Seeded pseudo-random based on seed + age for deterministic chaos
+    const t = this.age * 10;
+    const chaos = this.seededNoise(t);
+
+    const magnitude = this.intensity * TURBULENCE_STRENGTH * falloff;
+
+    return chaos.mul(magnitude);
+  }
+
+  /**
+   * Simple seeded noise function using LCG-based pseudo-random.
+   * Returns a unit vector in a pseudo-random direction.
+   */
+  private seededNoise(t: number): V2d {
+    // Linear congruential generator
+    let seed = this.seed + Math.floor(t);
+    seed = (seed * 1103515245 + 12345) | 0;
+    const x = ((seed >> 16) & 0x7fff) / 0x7fff - 0.5;
+    seed = (seed * 1103515245 + 12345) | 0;
+    const y = ((seed >> 16) & 0x7fff) / 0x7fff - 0.5;
+
+    return V(x * 2, y * 2);
+  }
+}

--- a/src/game/WindModifierSpatialHash.ts
+++ b/src/game/WindModifierSpatialHash.ts
@@ -1,0 +1,59 @@
+import { V2d } from "../core/Vector";
+import { WindModifier } from "./WindModifier";
+
+const DEFAULT_CELL_SIZE = 10; // Tunable - roughly matches typical influence radius
+
+/**
+ * Sparse spatial hash for efficient point queries against wind modifiers.
+ * Uses a Map so only non-empty cells exist in memory.
+ */
+export class WindModifierSpatialHash {
+  private cellSize: number;
+  private cells = new Map<number, WindModifier[]>();
+
+  constructor(cellSize: number = DEFAULT_CELL_SIZE) {
+    this.cellSize = cellSize;
+  }
+
+  /** Convert world position to cell key */
+  private getCellKey(x: number, y: number): number {
+    const cx = Math.floor(x / this.cellSize);
+    const cy = Math.floor(y / this.cellSize);
+    // Bit-packed key handles negative coords (works for ±32768 cells)
+    return ((cx + 0x8000) << 16) | ((cy + 0x8000) & 0xffff);
+  }
+
+  /** Add modifier to all cells its influence radius overlaps */
+  addModifier(modifier: WindModifier): void {
+    const pos = modifier.getWindModifierPosition();
+    const r = modifier.getWindModifierInfluenceRadius();
+
+    const minCX = Math.floor((pos.x - r) / this.cellSize);
+    const maxCX = Math.floor((pos.x + r) / this.cellSize);
+    const minCY = Math.floor((pos.y - r) / this.cellSize);
+    const maxCY = Math.floor((pos.y + r) / this.cellSize);
+
+    for (let cx = minCX; cx <= maxCX; cx++) {
+      for (let cy = minCY; cy <= maxCY; cy++) {
+        const key = ((cx + 0x8000) << 16) | ((cy + 0x8000) & 0xffff);
+        let cell = this.cells.get(key);
+        if (!cell) {
+          cell = [];
+          this.cells.set(key, cell);
+        }
+        cell.push(modifier);
+      }
+    }
+  }
+
+  /** Query modifiers that might affect a point */
+  queryPoint(point: V2d): readonly WindModifier[] {
+    const key = this.getCellKey(point.x, point.y);
+    return this.cells.get(key) ?? [];
+  }
+
+  /** Clear all cells (call before rebuild) */
+  clear(): void {
+    this.cells.clear();
+  }
+}


### PR DESCRIPTION
## Summary

- Add `WindModifierSpatialHash` for O(1) point queries against wind modifiers instead of iterating all modifiers
- Refactor `Wind` to use tag-based modifier discovery and spatial hash for efficient lookups
- Add `skipModifier` parameter to `getVelocityAtPoint` to prevent sails from querying their own wind effects (feedback loops)
- Implement directional wind effects in `SailWindEffect`:
  - Leeward acceleration (flow speedup on the leeward side of the sail)
  - Windward blockage (flow reduction on the windward side)
  - Wake shadow zone (reduced wind downwind of stalled sails)
- Add `TurbulenceParticle` entity spawned by stalled sail segments for chaotic downwind effects
- Use per-segment state tracking in sails for accurate local aerodynamics

## Test plan

- [ ] Verify sail lift behavior remains smooth during normal sailing
- [ ] Confirm wind effects don't create feedback loops (sail querying own effect)
- [ ] Test turbulence particles spawn when sail stalls and drift downwind
- [ ] Check performance with multiple sails/modifiers using spatial hash

🤖 Generated with [Claude Code](https://claude.com/claude-code)