### PR TITLE
Fix issue #16 in tack-and-trim

### DIFF
--- a/src/core/entity/BaseGameEvents.ts
+++ b/src/core/entity/BaseGameEvents.ts
@@ -15,9 +15,42 @@ export interface RenderEventData {
 }
 
 export type BaseGameEvents = {
-  /** Called when added to the game */
+  /**
+   * Called when added to the game, during the early phase of entity setup.
+   *
+   * At this point:
+   * - `this.game` is set and accessible
+   * - The entity is NOT yet in the EntityList
+   * - Physics bodies/springs/constraints are NOT yet in the world
+   * - Children have NOT been added yet
+   * - IO handlers are NOT yet registered
+   *
+   * Use `onAdd` when you need access to `this.game` to complete initialization
+   * but don't depend on physics or children being set up.
+   *
+   * If the entity is destroyed during onAdd (e.g., via `this.destroy()`),
+   * the entity will not be fully added to the game.
+   *
+   * @see onAfterAdded - Called after all setup is complete
+   */
   add: { game: Game; parent?: Entity };
-  /** Called right after being added to the game */
+  /**
+   * Called after the entity is fully added to the game.
+   *
+   * At this point:
+   * - `this.game` is set and accessible
+   * - The entity IS in the EntityList (can be found via tags, id, filters)
+   * - Physics bodies/springs/constraints ARE in the world
+   * - All children HAVE been added
+   * - IO handlers ARE registered
+   * - `onResize` has been called if the entity has that handler
+   *
+   * Use `onAfterAdded` when you need to interact with the fully initialized
+   * entity, such as querying other entities, accessing physics state, or
+   * relying on children being present.
+   *
+   * @see onAdd - Called during early setup before physics/children
+   */
   afterAdded: { game: Game };
   /** Called after physics */
   afterPhysics: void;

--- a/src/core/entity/Entity.ts
+++ b/src/core/entity/Entity.ts
@@ -28,7 +28,23 @@ export default interface Entity extends EventHandler<GameEventMap> {
   /** The game this entity belongs to. This should only be set by the Game. */
   game: Game | undefined;
 
-  /** TODO: Document entity.id */
+  /**
+   * Optional unique identifier for this entity within the game.
+   *
+   * When set, the entity can be retrieved via `game.entities.getById(id)`.
+   * IDs must be unique per Game instance - adding an entity with a duplicate ID
+   * will throw an error.
+   *
+   * Use this for singleton entities or entities that need to be referenced
+   * by other parts of the codebase without direct references.
+   *
+   * @example
+   * // In entity constructor or definition:
+   * this.id = "player";
+   *
+   * // Later, retrieve the entity:
+   * const player = game.entities.getById("player");
+   */
   id?: string;
   /** Tags to find entities by */
   readonly tags: ReadonlyArray<string>;

--- a/src/core/entity/WithOwner.ts
+++ b/src/core/entity/WithOwner.ts
@@ -1,8 +1,38 @@
 import Entity from "./Entity";
 
-/** TODO: document WithOwner */
-
+/**
+ * Interface for objects that can be associated with an owning Entity.
+ *
+ * This interface is primarily used by physics bodies and shapes to maintain
+ * a reference back to their owning Entity. When an entity with a `body` or
+ * `bodies` property is added to the game, the Game automatically sets the
+ * `owner` property on each body to point to the entity.
+ *
+ * This owner reference is essential for the collision system - when two
+ * physics bodies collide, the system uses the `owner` property to determine
+ * which entities are involved and dispatch the appropriate contact events
+ * (onBeginContact, onEndContact, onContacting, onImpact) to those entities.
+ *
+ * @example
+ * // The Game automatically sets owner when adding entities:
+ * // In Game.addEntity():
+ * if (entity.body) {
+ *   entity.body.owner = entity;
+ *   this.world.bodies.add(entity.body);
+ * }
+ *
+ * // In collision handlers, owner is used to find the entity:
+ * const ownerA = bodyA.owner;
+ * const ownerB = bodyB.owner;
+ * ownerA?.onBeginContact({ other: ownerB, ... });
+ */
 export interface WithOwner {
-  /** TODO: document WithOwner.owner */
+  /**
+   * The Entity that owns this object (typically a physics body or shape).
+   *
+   * This property is automatically set by the Game when an entity with
+   * physics bodies is added. It allows the physics/collision system to
+   * route events back to the appropriate Entity.
+   */
   owner?: Entity;
 }


### PR DESCRIPTION
Addresses issue #16 by documenting:
- Entity.id: explains uniqueness per Game instance, usage with getById()
- WithOwner interface: explains its role in linking physics bodies to entities for collision event routing
- Entity lifecycle hooks: clarifies the difference between onAdd (early setup, before EntityList/physics) and onAfterAdded (after full initialization)