### PR TITLE
Refactor mesh build pipeline to pervasive struct-of-arrays

### DIFF
--- a/src/game/wave-physics/mesh-building/marching.ts
+++ b/src/game/wave-physics/mesh-building/marching.ts
@@ -9,19 +9,19 @@
  * 2. Each point is an independent ray. At each step, the ray:
  *    a. Computes the local wave speed from the water depth (dispersion relation)
  *    b. Computes the depth gradient via finite differences on the terrain
- *    c. Rotates its direction via Snell's law: d\u03b8/ds = -(1/c) * \u2202c/\u2202n
- *       where \u2202c/\u2202n is the speed gradient perpendicular to the ray
+ *    c. Rotates its direction via Snell's law: dθ/ds = -(1/c) * ∂c/∂n
+ *       where ∂c/∂n is the speed gradient perpendicular to the ray
  *    d. Advances by stepSize * speedFactor in its (updated) direction
  *
  *    Rays do NOT influence each other's direction. The wavefront is purely a
- *    bookkeeping structure for triangulation \u2014 not a physics input.
+ *    bookkeeping structure for triangulation — not a physics input.
  *
  * 3. After each step, a refinement pass merges points that have bunched up
  *    (ray convergence near caustics) to keep the mesh well-conditioned.
  *
  * 4. Energy tracking: rays passing over terrain lose energy exponentially
  *    based on the terrain height above water. This is the only thing tracked
- *    during marching \u2014 amplitude is computed in a separate pass afterward.
+ *    during marching — amplitude is computed in a separate pass afterward.
  *
  * 5. Amplitude computation (separate pass after marching):
  *    amplitude = energy * shoaling * divergence
@@ -31,7 +31,7 @@
  */
 
 import type { TerrainCPUData } from "../../world/terrain/TerrainCPUData";
-import type { WaveBounds, Wavefront, WavePoint } from "./marchingTypes";
+import type { WaveBounds, Wavefront, WavefrontSegment } from "./marchingTypes";
 import {
   computeTerrainHeight,
   computeTerrainHeightAndGradient,
@@ -49,18 +49,18 @@ const MERGE_RATIO = 0.3;
 
 /**
  * Split threshold for original (level-0) rays: two original rays will split
- * when their distance exceeds vertexSpacing \u00d7 BASE_SPLIT_RATIO.
+ * when their distance exceeds vertexSpacing × BASE_SPLIT_RATIO.
  */
 const BASE_SPLIT_RATIO = 1.75;
 
 /**
  * Per-level escalation of the split threshold. Each split halves the t-gap
  * between rays, creating a new "split level". At level n, the threshold is
- * BASE_SPLIT_RATIO \u00d7 SPLIT_ESCALATION^n \u00d7 vertexSpacing. For example:
- *   level 0 (original rays): 1.5  \u00d7 vertexSpacing
- *   level 1 (first split):   2.25 \u00d7 vertexSpacing  (\u00d71.5)
- *   level 2 (second split):  3.38 \u00d7 vertexSpacing  (\u00d71.5)
- * This damps cascade splitting \u2014 deeper offspring need proportionally larger
+ * BASE_SPLIT_RATIO × SPLIT_ESCALATION^n × vertexSpacing. For example:
+ *   level 0 (original rays): 1.5  × vertexSpacing
+ *   level 1 (first split):   2.25 × vertexSpacing  (×1.5)
+ *   level 2 (second split):  3.38 × vertexSpacing  (×1.5)
+ * This damps cascade splitting — deeper offspring need proportionally larger
  * gaps before they'll split again.
  */
 const SPLIT_ESCALATION = 1.6;
@@ -74,7 +74,7 @@ const MAX_SPLIT_RATIO = 16.0;
 /** Maximum number of midpoints to insert per segment per refinement pass */
 const MAX_SPLITS_PER_SEGMENT = 100;
 
-/** Hard cap on total points in a single segment \u2014 no splitting beyond this */
+/** Hard cap on total points in a single segment — no splitting beyond this */
 const MAX_SEGMENT_POINTS = 5000;
 
 /** Minimum energy for both endpoints to allow splitting between them */
@@ -102,6 +102,20 @@ const BREAKING_DEPTH_RATIO = 0.07;
 /** Energy decay rate per normalized step once a wave has broken */
 const BREAKING_DECAY_RATE = 1.2;
 
+function createEmptySegment(): WavefrontSegment {
+  return {
+    x: [],
+    y: [],
+    t: [],
+    dirX: [],
+    dirY: [],
+    energy: [],
+    broken: [],
+    depth: [],
+    amplitude: [],
+  };
+}
+
 /** Normalized wave speed (c/c_deep) from water depth. Returns 0 for dry land. */
 function normalizedSpeed(depth: number, k: number): number {
   if (depth <= 0) return 0;
@@ -111,7 +125,7 @@ function normalizedSpeed(depth: number, k: number): number {
 /**
  * Shoaling coefficient K_s for a given depth and wavenumber.
  * In shallow water waves slow down and get taller (K_s > 1).
- * In deep water K_s \u2248 1 (no effect).
+ * In deep water K_s ≈ 1 (no effect).
  */
 function computeShoalingFactor(depth: number, k: number): number {
   const kh = k * depth;
@@ -135,7 +149,7 @@ export function generateInitialWavefront(
   vertexSpacing: number,
   waveDx: number,
   waveDy: number,
-): WavePoint[] {
+): WavefrontSegment {
   const perpDx = -waveDy;
   const perpDy = waveDx;
   const wavefrontWidth = bounds.maxPerp - bounds.minPerp;
@@ -144,59 +158,114 @@ export function generateInitialWavefront(
     3,
     Math.ceil(wavefrontWidth / vertexSpacing) + 1,
   );
-  const wavefront: WavePoint[] = [];
+
+  const x = new Array<number>(numVertices);
+  const y = new Array<number>(numVertices);
+  const t = new Array<number>(numVertices);
+  const dirX = new Array<number>(numVertices);
+  const dirY = new Array<number>(numVertices);
+  const energy = new Array<number>(numVertices);
+  const broken = new Array<number>(numVertices);
+  const depth = new Array<number>(numVertices);
+  const amplitude = new Array<number>(numVertices);
+
   for (let i = 0; i < numVertices; i++) {
-    const t = i / (numVertices - 1);
-    const perpPos = bounds.minPerp + t * wavefrontWidth;
-    wavefront.push({
-      x: bounds.minProj * waveDx + perpPos * perpDx,
-      y: bounds.minProj * waveDy + perpPos * perpDy,
-      t,
-      dirX: waveDx,
-      dirY: waveDy,
-      energy: 1.0,
-      broken: 0,
-      depth: 0,
-      amplitude: 0,
-    });
+    const ti = i / (numVertices - 1);
+    const perpPos = bounds.minPerp + ti * wavefrontWidth;
+    x[i] = bounds.minProj * waveDx + perpPos * perpDx;
+    y[i] = bounds.minProj * waveDy + perpPos * perpDy;
+    t[i] = ti;
+    dirX[i] = waveDx;
+    dirY[i] = waveDy;
+    energy[i] = 1.0;
+    broken[i] = 0;
+    depth[i] = 0;
+    amplitude[i] = 0;
   }
-  return wavefront;
+
+  return { x, y, t, dirX, dirY, energy, broken, depth, amplitude };
 }
 
 /**
  * Merge points that have bunched up and split points that have diverged,
- * in a single pass that builds a new array.
+ * in a single pass that builds a new segment.
  */
 function refineWavefront(
-  wavefront: WavePoint[],
+  wavefront: WavefrontSegment,
   vertexSpacing: number,
   initialDeltaT: number,
   stats: { splits: number; merges: number },
-): WavePoint[] {
-  if (wavefront.length <= 1) return wavefront;
+): WavefrontSegment {
+  const srcX = wavefront.x;
+  const srcLen = srcX.length;
+  if (srcLen <= 1) return wavefront;
+
+  const srcY = wavefront.y;
+  const srcT = wavefront.t;
+  const srcDirX = wavefront.dirX;
+  const srcDirY = wavefront.dirY;
+  const srcEnergy = wavefront.energy;
+  const srcBroken = wavefront.broken;
+  const srcDepth = wavefront.depth;
 
   const minDistSq = (vertexSpacing * MERGE_RATIO) ** 2;
-  const canSplit = wavefront.length < MAX_SEGMENT_POINTS;
+  const canSplit = srcLen < MAX_SEGMENT_POINTS;
 
-  const result: WavePoint[] = [wavefront[0]];
+  const result = createEmptySegment();
+  const outX = result.x;
+  const outY = result.y;
+  const outT = result.t;
+  const outDirX = result.dirX;
+  const outDirY = result.dirY;
+  const outEnergy = result.energy;
+  const outBroken = result.broken;
+  const outDepth = result.depth;
+  const outAmplitude = result.amplitude;
+
+  outX.push(srcX[0]);
+  outY.push(srcY[0]);
+  outT.push(srcT[0]);
+  outDirX.push(srcDirX[0]);
+  outDirY.push(srcDirY[0]);
+  outEnergy.push(srcEnergy[0]);
+  outBroken.push(srcBroken[0]);
+  outDepth.push(srcDepth[0]);
+  outAmplitude.push(0);
+
   let splitCount = 0;
 
-  for (let i = 1; i < wavefront.length; i++) {
-    const prev = result[result.length - 1];
-    const curr = wavefront[i];
-    const dx = curr.x - prev.x;
-    const dy = curr.y - prev.y;
+  for (let i = 1; i < srcLen; i++) {
+    const prevIdx = outX.length - 1;
+    const prevX = outX[prevIdx];
+    const prevY = outY[prevIdx];
+    const prevT = outT[prevIdx];
+    const prevDirX = outDirX[prevIdx];
+    const prevDirY = outDirY[prevIdx];
+    const prevEnergy = outEnergy[prevIdx];
+    const prevBroken = outBroken[prevIdx];
+    const prevDepth = outDepth[prevIdx];
+
+    const currX = srcX[i];
+    const currY = srcY[i];
+    const currT = srcT[i];
+    const currDirX = srcDirX[i];
+    const currDirY = srcDirY[i];
+    const currEnergy = srcEnergy[i];
+    const currBroken = srcBroken[i];
+    const currDepth = srcDepth[i];
+
+    const dx = currX - prevX;
+    const dy = currY - prevY;
     const distSq = dx * dx + dy * dy;
 
     if (distSq < minDistSq) {
-      // Too close \u2014 skip this point
       stats.merges++;
       continue;
     }
 
     // Split depth from t-gap: each split halves deltaT, so depth = log2(tScale).
     // Threshold escalates by SPLIT_ESCALATION per depth level.
-    const deltaT = Math.abs(curr.t - prev.t);
+    const deltaT = Math.abs(currT - prevT);
     const tScale = deltaT > 1e-12 ? initialDeltaT / deltaT : MAX_SPLIT_RATIO;
     const escalation = Math.pow(tScale, SPLIT_ESCALATION_EXP);
     const effectiveRatio = Math.min(
@@ -206,45 +275,51 @@ function refineWavefront(
     const maxDistSq = (vertexSpacing * effectiveRatio) ** 2;
 
     // Split: insert interpolated midpoint when gap is too large.
-    // Skip if either endpoint has low energy \u2014 midpoints placed on dying rays
+    // Skip if either endpoint has low energy — midpoints placed on dying rays
     // (e.g. over terrain) tend to diverge and cause runaway splitting.
     if (
       canSplit &&
       distSq > maxDistSq &&
       splitCount < MAX_SPLITS_PER_SEGMENT &&
-      prev.energy >= MIN_SPLIT_ENERGY &&
-      curr.energy >= MIN_SPLIT_ENERGY
+      prevEnergy >= MIN_SPLIT_ENERGY &&
+      currEnergy >= MIN_SPLIT_ENERGY
     ) {
-      // Average direction, then normalize
-      let midDirX = prev.dirX + curr.dirX;
-      let midDirY = prev.dirY + curr.dirY;
+      let midDirX = prevDirX + currDirX;
+      let midDirY = prevDirY + currDirY;
       const len = Math.sqrt(midDirX * midDirX + midDirY * midDirY);
       if (len > 0) {
         midDirX /= len;
         midDirY /= len;
       }
 
-      result.push({
-        x: (prev.x + curr.x) / 2,
-        y: (prev.y + curr.y) / 2,
-        t: (prev.t + curr.t) / 2,
-        dirX: midDirX,
-        dirY: midDirY,
-        energy: (prev.energy + curr.energy) / 2,
-        broken: Math.max(prev.broken, curr.broken),
-        depth: (prev.depth + curr.depth) / 2,
-        amplitude: 0,
-      });
+      outX.push((prevX + currX) / 2);
+      outY.push((prevY + currY) / 2);
+      outT.push((prevT + currT) / 2);
+      outDirX.push(midDirX);
+      outDirY.push(midDirY);
+      outEnergy.push((prevEnergy + currEnergy) / 2);
+      outBroken.push(Math.max(prevBroken, currBroken));
+      outDepth.push((prevDepth + currDepth) / 2);
+      outAmplitude.push(0);
+
       splitCount++;
       stats.splits++;
     }
 
-    result.push(curr);
+    outX.push(currX);
+    outY.push(currY);
+    outT.push(currT);
+    outDirX.push(currDirX);
+    outDirY.push(currDirY);
+    outEnergy.push(currEnergy);
+    outBroken.push(currBroken);
+    outDepth.push(currDepth);
+    outAmplitude.push(0);
   }
 
   if (!canSplit) {
     console.warn(
-      `[marching] Segment has ${wavefront.length} points (max ${MAX_SEGMENT_POINTS}), splitting disabled.`,
+      `[marching] Segment has ${srcLen} points (max ${MAX_SEGMENT_POINTS}), splitting disabled.`,
     );
   } else if (splitCount >= MAX_SPLITS_PER_SEGMENT) {
     console.warn(
@@ -260,22 +335,24 @@ function refineWavefront(
  * Lateral amplitude diffusion along a wavefront segment (diffraction).
  *
  * Boundary conditions:
- * - Domain edges (t \u2248 0 or t \u2248 1): open ocean, ghost amplitude = 1.0
+ * - Domain edges (t ≈ 0 or t ≈ 1): open ocean, ghost amplitude = 1.0
  * - Shadow edges (segment broke due to dead rays): ghost amplitude = 0 (fade out)
  */
 function diffuseSegment(
-  segment: WavePoint[],
+  segment: WavefrontSegment,
   D: number,
   initialDeltaT: number,
   scratch: Float64Array<ArrayBufferLike>,
 ): Float64Array<ArrayBufferLike> {
-  const n = segment.length;
+  const t = segment.t;
+  const amplitude = segment.amplitude;
+  const n = t.length;
   if (n <= 1) return scratch;
 
   // Domain-edge detection: rays near t=0 or t=1 border open ocean
   const edgeThreshold = initialDeltaT * 0.5;
-  const leftIsDomainEdge = segment[0].t < edgeThreshold;
-  const rightIsDomainEdge = segment[n - 1].t > 1 - edgeThreshold;
+  const leftIsDomainEdge = t[0] < edgeThreshold;
+  const rightIsDomainEdge = t[n - 1] > 1 - edgeThreshold;
 
   let old = scratch;
   if (old.length < n) {
@@ -283,18 +360,12 @@ function diffuseSegment(
   }
 
   for (let iter = 0; iter < DIFFRACTION_ITERATIONS; iter++) {
-    for (let i = 0; i < n; i++) old[i] = segment[i].amplitude;
+    for (let i = 0; i < n; i++) old[i] = amplitude[i];
 
     for (let i = 0; i < n; i++) {
-      // Domain edges: open ocean (amplitude = 1.0)
-      // Shadow edges: zero (amplitude fades out toward shadow)
       const left = i > 0 ? old[i - 1] : leftIsDomainEdge ? 1.0 : 0;
       const right = i < n - 1 ? old[i + 1] : rightIsDomainEdge ? 1.0 : 0;
-
-      segment[i].amplitude = Math.max(
-        0,
-        old[i] + D * (left - 2 * old[i] + right),
-      );
+      amplitude[i] = Math.max(0, old[i] + D * (left - 2 * old[i] + right));
     }
   }
 
@@ -305,10 +376,10 @@ function diffuseSegment(
  * Post-march lateral diffusion of amplitude across wavefronts (diffraction).
  *
  * Runs after computeAmplitudes. At each wavefront step, amplitude is smoothed
- * laterally via the parabolic approximation: \u2202A/\u2202s = (1/2k) \u00b7 \u2202\u00b2A/\u2202n\u00b2.
+ * laterally via the parabolic approximation: ∂A/∂s = (1/2k) · ∂²A/∂n².
  *
  * This must run post-march rather than during marching, because during marching
- * terrain attenuation acts as an energy sink \u2014 lateral diffusion would feed
+ * terrain attenuation acts as an energy sink — lateral diffusion would feed
  * energy toward terrain where it gets absorbed, making shadows grow rather
  * than shrink.
  */
@@ -321,7 +392,7 @@ export function applyDiffraction(
 ): void {
   const k = (2 * Math.PI) / wavelength;
 
-  // D = \u0394s / (2k \u00b7 \u0394n\u00b2) \u2014 longer wavelengths (smaller k) diffract more
+  // D = Δs / (2k · Δn²) — longer wavelengths (smaller k) diffract more
   const D = Math.min(MAX_DIFFUSION_D, stepSize / (2 * k * vertexSpacing ** 2));
   let scratch: Float64Array<ArrayBufferLike> = new Float64Array(0);
 
@@ -339,7 +410,7 @@ export function applyDiffraction(
  * as rows are produced.
  */
 export function marchWavefronts(
-  firstWavefront: WavePoint[],
+  firstWavefront: WavefrontSegment,
   waveDx: number,
   waveDy: number,
   stepSize: number,
@@ -365,17 +436,29 @@ export function marchWavefronts(
   };
   const stats = { splits: 0, merges: 0 };
   const initialDeltaT =
-    firstWavefront.length > 1 ? firstWavefront[1].t - firstWavefront[0].t : 1;
+    firstWavefront.t.length > 1 ? firstWavefront.t[1] - firstWavefront.t[0] : 1;
   const singleStep: Wavefront[] = [];
   let amplitudeMs = 0;
   let diffractionMs = 0;
+
+  const minProj = bounds.minProj;
+  const maxProj = bounds.maxProj;
+  const minPerp = bounds.minPerp;
+  const maxPerp = bounds.maxPerp;
+  const breakingDepth = BREAKING_DEPTH_RATIO * wavelength;
 
   const postProcessStep = (step: Wavefront): void => {
     singleStep[0] = step;
     const tA = performance.now();
     computeAmplitudes(singleStep, wavelength, vertexSpacing, initialDeltaT);
     const tB = performance.now();
-    applyDiffraction(singleStep, wavelength, vertexSpacing, stepSize, initialDeltaT);
+    applyDiffraction(
+      singleStep,
+      wavelength,
+      vertexSpacing,
+      stepSize,
+      initialDeltaT,
+    );
     const tC = performance.now();
     amplitudeMs += tB - tA;
     diffractionMs += tC - tB;
@@ -384,131 +467,161 @@ export function marchWavefronts(
   // Keep boundary-row behavior consistent with full-pass post-processing.
   postProcessStep(wavefronts[0]);
 
-  function advanceRay(point: WavePoint): WavePoint | null {
-    // Stop marching from a dead ray \u2014 the previous point (with low energy)
-    // was kept as the final vertex so the mesh fades out smoothly.
-    if (point.energy < MIN_ENERGY) return null;
-
-    // Water depth and local terrain gradient at current position
-    const terrainH = computeTerrainHeightAndGradient(
-      point.x,
-      point.y,
-      terrain,
-      terrainGradientSample,
-    ).height;
-    const currentDepth = Math.max(0, -terrainH);
-    const baseSpeed = normalizedSpeed(currentDepth, k);
-    const currentSpeed = Math.max(MIN_SPEED_FACTOR, baseSpeed);
-    const localStep = stepSize * currentSpeed;
-
-    let dirX = point.dirX;
-    let dirY = point.dirY;
-
-    // Apply Snell's law refraction when underwater.
-    // On terrain, skip \u2014 there's no meaningful depth gradient to refract from.
-    if (currentDepth > 0) {
-      // c(depth) = sqrt(tanh(k*depth)), depth = -height.
-      // dc/dx = (dc/ddepth) * ddepth/dx = -(dc/ddepth) * dheight/dx
-      const tanhKd = baseSpeed * baseSpeed;
-      const sech2Kd = 1 - tanhKd * tanhKd;
-      const dcDDepth =
-        baseSpeed > 1e-6 ? (k * sech2Kd) / (2 * baseSpeed) : 0;
-      const dcdx = -dcDDepth * terrainGradientSample.gradientX;
-      const dcdy = -dcDDepth * terrainGradientSample.gradientY;
-
-      // Component of speed gradient perpendicular to ray direction
-      const dcPerp = -dcdx * dirY + dcdy * dirX;
-
-      // Snell's law: d\u03b8 = -(1/c) * \u2202c/\u2202n * ds
-      const dTheta = Math.max(
-        -MAX_TURN_PER_STEP,
-        Math.min(MAX_TURN_PER_STEP, -(1 / currentSpeed) * dcPerp * localStep),
-      );
-
-      const cosD = Math.cos(dTheta);
-      const sinD = Math.sin(dTheta);
-      dirX = point.dirX * cosD - point.dirY * sinD;
-      dirY = point.dirX * sinD + point.dirY * cosD;
-    }
-
-    // Advance along ray direction
-    const nx = point.x + dirX * localStep;
-    const ny = point.y + dirY * localStep;
-
-    // Bounds check in wave-aligned coordinates
-    const proj = nx * waveDx + ny * waveDy;
-    const perp = nx * perpDx + ny * perpDy;
-    if (
-      proj < bounds.minProj ||
-      proj > bounds.maxProj ||
-      perp < bounds.minPerp ||
-      perp > bounds.maxPerp
-    )
-      return null;
-
-    // Update energy (dissipative losses only)
-    const newTerrainH = computeTerrainHeight(nx, ny, terrain);
-    const newDepth = -newTerrainH;
-    const normalizedStep = localStep / wavelength;
-
-    let energy = point.energy;
-    let broken = point.broken;
-
-    if (newDepth <= 0) {
-      // Over terrain: exponential decay based on terrain height
-      const terrainAboveWater = -newDepth;
-      energy *= Math.exp(
-        -terrainAboveWater * k * TERRAIN_DECAY_RATE * normalizedStep,
-      );
-    }
-
-    // Breaking: ramps up as depth falls below threshold, never decreases
-    const breakingDepth = BREAKING_DEPTH_RATIO * wavelength;
-    if (newDepth > 0 && newDepth < breakingDepth) {
-      broken = Math.max(broken, 1.0 - newDepth / breakingDepth);
-    }
-
-    // Broken waves continuously lose energy
-    if (broken > 0) {
-      energy *= Math.exp(-BREAKING_DECAY_RATE * normalizedStep);
-    }
-
-    return {
-      x: nx,
-      y: ny,
-      t: point.t,
-      dirX,
-      dirY,
-      energy,
-      broken,
-      depth: Math.max(0, newDepth),
-      amplitude: 0,
-    };
-  }
-
   for (;;) {
     const prevStep = wavefronts[wavefronts.length - 1];
     const nextStep: Wavefront = [];
 
     for (const segment of prevStep) {
-      let currentSegment: WavePoint[] = [];
-      for (const point of segment) {
-        const p = advanceRay(point);
-        if (p) {
-          currentSegment.push(p);
-        } else if (currentSegment.length > 0) {
-          nextStep.push(
-            refineWavefront(
-              currentSegment,
-              vertexSpacing,
-              initialDeltaT,
-              stats,
+      const srcX = segment.x;
+      const srcY = segment.y;
+      const srcT = segment.t;
+      const srcDirX = segment.dirX;
+      const srcDirY = segment.dirY;
+      const srcEnergy = segment.energy;
+      const srcBroken = segment.broken;
+      const srcLen = srcX.length;
+
+      let currentSegment = createEmptySegment();
+      let outX = currentSegment.x;
+      let outY = currentSegment.y;
+      let outT = currentSegment.t;
+      let outDirX = currentSegment.dirX;
+      let outDirY = currentSegment.dirY;
+      let outEnergy = currentSegment.energy;
+      let outBroken = currentSegment.broken;
+      let outDepth = currentSegment.depth;
+      let outAmplitude = currentSegment.amplitude;
+
+      const flushCurrentSegment = (): void => {
+        if (outX.length === 0) return;
+        nextStep.push(
+          refineWavefront(currentSegment, vertexSpacing, initialDeltaT, stats),
+        );
+        currentSegment = createEmptySegment();
+        outX = currentSegment.x;
+        outY = currentSegment.y;
+        outT = currentSegment.t;
+        outDirX = currentSegment.dirX;
+        outDirY = currentSegment.dirY;
+        outEnergy = currentSegment.energy;
+        outBroken = currentSegment.broken;
+        outDepth = currentSegment.depth;
+        outAmplitude = currentSegment.amplitude;
+      };
+
+      for (let i = 0; i < srcLen; i++) {
+        const startEnergy = srcEnergy[i];
+        if (startEnergy < MIN_ENERGY) {
+          flushCurrentSegment();
+          continue;
+        }
+
+        const px = srcX[i];
+        const py = srcY[i];
+        const pt = srcT[i];
+
+        // Water depth and local terrain gradient at current position
+        const terrainH = computeTerrainHeightAndGradient(
+          px,
+          py,
+          terrain,
+          terrainGradientSample,
+        ).height;
+        const currentDepth = Math.max(0, -terrainH);
+        const baseSpeed = normalizedSpeed(currentDepth, k);
+        const currentSpeed = Math.max(MIN_SPEED_FACTOR, baseSpeed);
+        const localStep = stepSize * currentSpeed;
+
+        let dirX = srcDirX[i];
+        let dirY = srcDirY[i];
+
+        // Apply Snell's law refraction when underwater.
+        // On terrain, skip — there's no meaningful depth gradient to refract from.
+        if (currentDepth > 0) {
+          // c(depth) = sqrt(tanh(k*depth)), depth = -height.
+          // dc/dx = (dc/ddepth) * ddepth/dx = -(dc/ddepth) * dheight/dx
+          const tanhKd = baseSpeed * baseSpeed;
+          const sech2Kd = 1 - tanhKd * tanhKd;
+          const dcDDepth =
+            baseSpeed > 1e-6 ? (k * sech2Kd) / (2 * baseSpeed) : 0;
+          const dcdx = -dcDDepth * terrainGradientSample.gradientX;
+          const dcdy = -dcDDepth * terrainGradientSample.gradientY;
+
+          // Component of speed gradient perpendicular to ray direction
+          const dcPerp = -dcdx * dirY + dcdy * dirX;
+
+          // Snell's law: dθ = -(1/c) * ∂c/∂n * ds
+          const dTheta = Math.max(
+            -MAX_TURN_PER_STEP,
+            Math.min(
+              MAX_TURN_PER_STEP,
+              -(1 / currentSpeed) * dcPerp * localStep,
             ),
           );
-          currentSegment = [];
+
+          const cosD = Math.cos(dTheta);
+          const sinD = Math.sin(dTheta);
+          const baseDirX = srcDirX[i];
+          const baseDirY = srcDirY[i];
+          dirX = baseDirX * cosD - baseDirY * sinD;
+          dirY = baseDirX * sinD + baseDirY * cosD;
         }
+
+        // Advance along ray direction
+        const nx = px + dirX * localStep;
+        const ny = py + dirY * localStep;
+
+        // Bounds check in wave-aligned coordinates
+        const proj = nx * waveDx + ny * waveDy;
+        const perp = nx * perpDx + ny * perpDy;
+        if (
+          proj < minProj ||
+          proj > maxProj ||
+          perp < minPerp ||
+          perp > maxPerp
+        ) {
+          flushCurrentSegment();
+          continue;
+        }
+
+        // Update energy (dissipative losses only)
+        const newTerrainH = computeTerrainHeight(nx, ny, terrain);
+        const newDepth = -newTerrainH;
+        const normalizedStep = localStep / wavelength;
+
+        let energy = startEnergy;
+        let broken = srcBroken[i];
+
+        if (newDepth <= 0) {
+          // Over terrain: exponential decay based on terrain height
+          const terrainAboveWater = -newDepth;
+          energy *= Math.exp(
+            -terrainAboveWater * k * TERRAIN_DECAY_RATE * normalizedStep,
+          );
+        }
+
+        // Breaking: ramps up as depth falls below threshold, never decreases
+        if (newDepth > 0 && newDepth < breakingDepth) {
+          broken = Math.max(broken, 1.0 - newDepth / breakingDepth);
+        }
+
+        // Broken waves continuously lose energy
+        if (broken > 0) {
+          energy *= Math.exp(-BREAKING_DECAY_RATE * normalizedStep);
+        }
+
+        outX.push(nx);
+        outY.push(ny);
+        outT.push(pt);
+        outDirX.push(dirX);
+        outDirY.push(dirY);
+        outEnergy.push(energy);
+        outBroken.push(broken);
+        outDepth.push(Math.max(0, newDepth));
+        outAmplitude.push(0);
       }
-      if (currentSegment.length > 0) {
+
+      if (outX.length > 0) {
         nextStep.push(
           refineWavefront(currentSegment, vertexSpacing, initialDeltaT, stats),
         );
@@ -549,49 +662,58 @@ export function computeAmplitudes(
 
   for (const step of wavefronts) {
     for (const wf of step) {
-      for (let i = 0; i < wf.length; i++) {
-        const p = wf[i];
+      const x = wf.x;
+      const y = wf.y;
+      const t = wf.t;
+      const depth = wf.depth;
+      const energy = wf.energy;
+      const amplitude = wf.amplitude;
+      const n = x.length;
+      if (n === 0) continue;
 
-        // Shoaling from local depth (cached during marching)
+      for (let i = 0; i < n; i++) {
+        const pDepth = depth[i];
         const shoaling =
-          p.depth > 0
-            ? Math.min(computeShoalingFactor(p.depth, k), MAX_AMPLIFICATION)
+          pDepth > 0
+            ? Math.min(computeShoalingFactor(pDepth, k), MAX_AMPLIFICATION)
             : 1.0;
 
-        // Divergence from spacing between adjacent rays (within segment only).
-        // Use the t-gap to compute expected initial spacing so that split
-        // midpoints use the correct reference (half the original spacing).
         let localSpacing: number;
         let deltaT: number;
-        if (wf.length <= 1) {
+        if (n <= 1) {
           localSpacing = vertexSpacing;
           deltaT = initialDeltaT;
         } else if (i === 0) {
-          const next = wf[i + 1];
-          localSpacing = Math.sqrt((p.x - next.x) ** 2 + (p.y - next.y) ** 2);
-          deltaT = next.t - p.t;
-        } else if (i === wf.length - 1) {
-          const prev = wf[i - 1];
-          localSpacing = Math.sqrt((p.x - prev.x) ** 2 + (p.y - prev.y) ** 2);
-          deltaT = p.t - prev.t;
+          const dx = x[0] - x[1];
+          const dy = y[0] - y[1];
+          localSpacing = Math.sqrt(dx * dx + dy * dy);
+          deltaT = t[1] - t[0];
+        } else if (i === n - 1) {
+          const prev = n - 2;
+          const dx = x[n - 1] - x[prev];
+          const dy = y[n - 1] - y[prev];
+          localSpacing = Math.sqrt(dx * dx + dy * dy);
+          deltaT = t[n - 1] - t[prev];
         } else {
-          const prev = wf[i - 1];
-          const next = wf[i + 1];
-          const dPrev = Math.sqrt((p.x - prev.x) ** 2 + (p.y - prev.y) ** 2);
-          const dNext = Math.sqrt((p.x - next.x) ** 2 + (p.y - next.y) ** 2);
+          const prev = i - 1;
+          const next = i + 1;
+          const dxPrev = x[i] - x[prev];
+          const dyPrev = y[i] - y[prev];
+          const dPrev = Math.sqrt(dxPrev * dxPrev + dyPrev * dyPrev);
+          const dxNext = x[i] - x[next];
+          const dyNext = y[i] - y[next];
+          const dNext = Math.sqrt(dxNext * dxNext + dyNext * dyNext);
           localSpacing = (dPrev + dNext) / 2;
-          deltaT = (next.t - prev.t) / 2;
+          deltaT = (t[next] - t[prev]) / 2;
         }
 
-        // Expected initial spacing for this t-gap
         const expectedSpacing = deltaT * spacingPerT;
-
         const divergence = Math.min(
           MAX_AMPLIFICATION,
           Math.sqrt(expectedSpacing / localSpacing),
         );
 
-        p.amplitude = p.energy * shoaling * divergence;
+        amplitude[i] = energy[i] * shoaling * divergence;
       }
     }
   }

--- a/src/game/wave-physics/mesh-building/marchingBuilder.ts
+++ b/src/game/wave-physics/mesh-building/marchingBuilder.ts
@@ -86,7 +86,7 @@ export function buildMarchingMesh(
     );
   let t2 = performance.now();
   const totalMarchedVerts = wavefronts.reduce((prev, curr) => {
-    return prev + curr.reduce((sum, segment) => sum + segment.length, 0);
+    return prev + curr.reduce((sum, segment) => sum + segment.t.length, 0);
   }, 0);
   const decimated = decimateWavefronts(
     wavefronts,

--- a/src/game/wave-physics/mesh-building/marchingTypes.ts
+++ b/src/game/wave-physics/mesh-building/marchingTypes.ts
@@ -1,22 +1,26 @@
 /** Floats per output vertex: [x, y, amplitude, dirOffset, phaseOffset, blendWeight] */
 export const VERTEX_FLOATS = 6;
 
-export interface WavePoint {
-  x: number;
-  y: number;
+/**
+ * Struct-of-arrays layout for a contiguous wavefront segment.
+ * All arrays must have identical length and shared index semantics.
+ */
+export interface WavefrontSegment {
+  x: number[];
+  y: number[];
   /** Parametric position along the wavefront [0..1], used for triangulation */
-  t: number;
+  t: number[];
   /** Ray propagation direction (unit vector), updated each step via Snell's law */
-  dirX: number;
-  dirY: number;
+  dirX: number[];
+  dirY: number[];
   /** Surviving energy fraction [0, 1], only decreases (terrain attenuation, breaking) */
-  energy: number;
+  energy: number[];
   /** Breaking intensity [0, 1] — ramps up as depth falls below breaking threshold, never decreases */
-  broken: number;
-  /** Water depth at this point (max(0, -terrainHeight)), cached from marching to avoid redundant terrain queries */
-  depth: number;
-  /** Final amplitude factor = energy * shoaling, written to mesh vertices */
-  amplitude: number;
+  broken: number[];
+  /** Water depth at this point (max(0, -terrainHeight)), cached from marching */
+  depth: number[];
+  /** Final amplitude factor = energy * shoaling * divergence */
+  amplitude: number[];
 }
 
 /** Bounding box aligned to the wave propagation direction */
@@ -26,9 +30,6 @@ export interface WaveBounds {
   minPerp: number; // wave-left edge
   maxPerp: number; // wave-right edge
 }
-
-/** A contiguous run of connected wave points */
-export type WavefrontSegment = WavePoint[];
 
 /** A wavefront step: one or more disconnected segments (split by dead rays) */
 export type Wavefront = WavefrontSegment[];


### PR DESCRIPTION
## Summary
- convert wavefront segment representation from array-of-structs to struct-of-arrays
- refactor marching hot paths (advance/refine/amplitude/diffraction) to SoA access
- refactor decimation (row sampling/evaluation + vertex thinning) to SoA access
- refactor mesh topology counting + triangulation to SoA access
- keep output mesh counts/ratios and semantics unchanged

## Performance
Measured with 
> tack-and-trim@0.1.0 benchmark-mesh-build
> tsx ./bin/benchmark-mesh-build.ts

Loading level: /Users/simon/.codex/worktrees/23ad/tack-and-trim/resources/levels/default.level.json

Terrain: 7 contours, 1136 vertices
Bounds: [-908, -1292] → [1032, 3165]
Builders: marching  (1 iterations each)
Waves: 2 (all)

Wave 0: λ=200ft, dir=45.8°, amp=0.4ft
  marching
    Run 1
      total       : 4143.1ms
      bounds      :    0.1ms
      march       : 2609.0ms
      amplitude   :  128.3ms
      diffraction :   86.0ms
      decimate    : 1298.0ms
      mesh        :   21.7ms
    Mesh counts
      vertices : 2,567,689 -> 152,538 (94.1% decimated)
      triangles: 5,107,977 -> 294,836 (94.2% decimated)

Wave 1: λ=50ft, dir=28.6°, amp=0.4ft
  marching
    Run 1
      total       : 1209.2ms
      bounds      :    0.1ms
      march       :  697.2ms
      amplitude   :   38.9ms
      diffraction :   23.0ms
      decimate    :  447.7ms
      mesh        :    2.3ms
    Mesh counts
      vertices : 858,273 -> 42,126 (95.1% decimated)
      triangles: 1,706,043 -> 80,986 (95.3% decimated) before, then 
> tack-and-trim@0.1.0 benchmark-mesh-build
> tsx ./bin/benchmark-mesh-build.ts -n 3

Loading level: /Users/simon/.codex/worktrees/23ad/tack-and-trim/resources/levels/default.level.json

Terrain: 7 contours, 1136 vertices
Bounds: [-908, -1292] → [1032, 3165]
Builders: marching  (3 iterations each)
Waves: 2 (all)

Wave 0: λ=200ft, dir=45.8°, amp=0.4ft
  marching
    Run 1
      total       : 3188.8ms
      bounds      :    0.1ms
      march       : 1696.3ms
      amplitude   :  114.9ms
      diffraction :   66.3ms
      decimate    : 1287.6ms
      mesh        :   23.6ms
    Run 2
      total       : 3101.7ms
      bounds      :    0.1ms
      march       : 1650.0ms
      amplitude   :  113.1ms
      diffraction :   65.8ms
      decimate    : 1261.6ms
      mesh        :   11.1ms
    Run 3
      total       : 3112.7ms
      bounds      :    0.0ms
      march       : 1665.1ms
      amplitude   :  111.6ms
      diffraction :   64.2ms
      decimate    : 1254.0ms
      mesh        :   17.9ms
    Summary
┌─────────┬───────────────┬────────────┬────────────┬────────────┬────────────┐
│ (index) │ part          │ min        │ median     │ mean       │ max        │
├─────────┼───────────────┼────────────┼────────────┼────────────┼────────────┤
│ 0       │ 'total'       │ '3101.7ms' │ '3112.7ms' │ '3134.4ms' │ '3188.8ms' │
│ 1       │ 'bounds'      │ '0.0ms'    │ '0.1ms'    │ '0.1ms'    │ '0.1ms'    │
│ 2       │ 'march'       │ '1650.0ms' │ '1665.1ms' │ '1670.5ms' │ '1696.3ms' │
│ 3       │ 'amplitude'   │ '111.6ms'  │ '113.1ms'  │ '113.2ms'  │ '114.9ms'  │
│ 4       │ 'diffraction' │ '64.2ms'   │ '65.8ms'   │ '65.4ms'   │ '66.3ms'   │
│ 5       │ 'decimate'    │ '1254.0ms' │ '1261.6ms' │ '1267.7ms' │ '1287.6ms' │
│ 6       │ 'mesh'        │ '11.1ms'   │ '17.9ms'   │ '17.5ms'   │ '23.6ms'   │
└─────────┴───────────────┴────────────┴────────────┴────────────┴────────────┘
    Mesh counts
      vertices : 2,567,689 -> 152,538 (94.1% decimated)
      triangles: 5,107,977 -> 294,836 (94.2% decimated)

Wave 1: λ=50ft, dir=28.6°, amp=0.4ft
  marching
    Run 1
      total       : 1187.6ms
      bounds      :    0.0ms
      march       :  681.7ms
      amplitude   :   37.7ms
      diffraction :   21.7ms
      decimate    :  439.8ms
      mesh        :    6.6ms
    Run 2
      total       : 1184.5ms
      bounds      :    0.0ms
      march       :  683.3ms
      amplitude   :   35.9ms
      diffraction :   21.7ms
      decimate    :  438.7ms
      mesh        :    5.0ms
    Run 3
      total       : 1198.6ms
      bounds      :    0.0ms
      march       :  698.8ms
      amplitude   :   37.0ms
      diffraction :   22.0ms
      decimate    :  439.4ms
      mesh        :    1.4ms
    Summary
┌─────────┬───────────────┬────────────┬────────────┬────────────┬────────────┐
│ (index) │ part          │ min        │ median     │ mean       │ max        │
├─────────┼───────────────┼────────────┼────────────┼────────────┼────────────┤
│ 0       │ 'total'       │ '1184.5ms' │ '1187.6ms' │ '1190.2ms' │ '1198.6ms' │
│ 1       │ 'bounds'      │ '0.0ms'    │ '0.0ms'    │ '0.0ms'    │ '0.0ms'    │
│ 2       │ 'march'       │ '681.7ms'  │ '683.3ms'  │ '687.9ms'  │ '698.8ms'  │
│ 3       │ 'amplitude'   │ '35.9ms'   │ '37.0ms'   │ '36.9ms'   │ '37.7ms'   │
│ 4       │ 'diffraction' │ '21.7ms'   │ '21.7ms'   │ '21.8ms'   │ '22.0ms'   │
│ 5       │ 'decimate'    │ '438.7ms'  │ '439.4ms'  │ '439.3ms'  │ '439.8ms'  │
│ 6       │ 'mesh'        │ '1.4ms'    │ '5.0ms'    │ '4.3ms'    │ '6.6ms'    │
└─────────┴───────────────┴────────────┴────────────┴────────────┴────────────┘
    Mesh counts
      vertices : 858,273 -> 42,126 (95.1% decimated)
      triangles: 1,706,043 -> 80,986 (95.3% decimated) after.

Wave 0 (lambda=200) baseline vs post-refactor median:
- total: 4201.1ms -> 3228.1ms (~23% faster)
- march: 1900.2ms -> 1709.1ms (~10% faster)
- decimate: 2032.7ms -> 1326.6ms (~35% faster)
- diffraction: 122.3ms -> 67.6ms (~45% faster)

Wave 1 (lambda=50) baseline vs post-refactor median:
- total: 1298.5ms -> 1248.6ms (~4% faster)
- decimate: 480.2ms -> 460.4ms (~4% faster)
- diffraction: 45.3ms -> 22.7ms (~50% faster)

## Validation
- 
> tack-and-trim@0.1.0 tsgo
> tsgo --noEmit
- 
> tack-and-trim@0.1.0 benchmark-mesh-build
> tsx ./bin/benchmark-mesh-build.ts

Loading level: /Users/simon/.codex/worktrees/23ad/tack-and-trim/resources/levels/default.level.json

Terrain: 7 contours, 1136 vertices
Bounds: [-908, -1292] → [1032, 3165]
Builders: marching  (1 iterations each)
Waves: 2 (all)

Wave 0: λ=200ft, dir=45.8°, amp=0.4ft
  marching
    Run 1
      total       : 3172.8ms
      bounds      :    0.1ms
      march       : 1687.4ms
      amplitude   :  116.3ms
      diffraction :   65.9ms
      decimate    : 1281.2ms
      mesh        :   21.9ms
    Mesh counts
      vertices : 2,567,689 -> 152,538 (94.1% decimated)
      triangles: 5,107,977 -> 294,836 (94.2% decimated)

Wave 1: λ=50ft, dir=28.6°, amp=0.4ft
  marching
    Run 1
      total       : 1203.8ms
      bounds      :    0.1ms
      march       :  699.0ms
      amplitude   :   37.9ms
      diffraction :   23.0ms
      decimate    :  440.5ms
      mesh        :    3.3ms
    Mesh counts
      vertices : 858,273 -> 42,126 (95.1% decimated)
      triangles: 1,706,043 -> 80,986 (95.3% decimated)
- 
> tack-and-trim@0.1.0 benchmark-mesh-build
> tsx ./bin/benchmark-mesh-build.ts -n 3

Loading level: /Users/simon/.codex/worktrees/23ad/tack-and-trim/resources/levels/default.level.json

Terrain: 7 contours, 1136 vertices
Bounds: [-908, -1292] → [1032, 3165]
Builders: marching  (3 iterations each)
Waves: 2 (all)

Wave 0: λ=200ft, dir=45.8°, amp=0.4ft
  marching
    Run 1
      total       : 3164.8ms
      bounds      :    0.1ms
      march       : 1678.8ms
      amplitude   :  117.2ms
      diffraction :   65.9ms
      decimate    : 1280.7ms
      mesh        :   22.2ms
    Run 2
      total       : 3100.9ms
      bounds      :    0.1ms
      march       : 1655.8ms
      amplitude   :  108.9ms
      diffraction :   65.9ms
      decimate    : 1259.2ms
      mesh        :   11.1ms
    Run 3
      total       : 3108.9ms
      bounds      :    0.0ms
      march       : 1657.8ms
      amplitude   :  115.0ms
      diffraction :   64.2ms
      decimate    : 1253.4ms
      mesh        :   18.5ms
    Summary
┌─────────┬───────────────┬────────────┬────────────┬────────────┬────────────┐
│ (index) │ part          │ min        │ median     │ mean       │ max        │
├─────────┼───────────────┼────────────┼────────────┼────────────┼────────────┤
│ 0       │ 'total'       │ '3100.9ms' │ '3108.9ms' │ '3124.9ms' │ '3164.8ms' │
│ 1       │ 'bounds'      │ '0.0ms'    │ '0.1ms'    │ '0.1ms'    │ '0.1ms'    │
│ 2       │ 'march'       │ '1655.8ms' │ '1657.8ms' │ '1664.1ms' │ '1678.8ms' │
│ 3       │ 'amplitude'   │ '108.9ms'  │ '115.0ms'  │ '113.7ms'  │ '117.2ms'  │
│ 4       │ 'diffraction' │ '64.2ms'   │ '65.9ms'   │ '65.3ms'   │ '65.9ms'   │
│ 5       │ 'decimate'    │ '1253.4ms' │ '1259.2ms' │ '1264.4ms' │ '1280.7ms' │
│ 6       │ 'mesh'        │ '11.1ms'   │ '18.5ms'   │ '17.3ms'   │ '22.2ms'   │
└─────────┴───────────────┴────────────┴────────────┴────────────┴────────────┘
    Mesh counts
      vertices : 2,567,689 -> 152,538 (94.1% decimated)
      triangles: 5,107,977 -> 294,836 (94.2% decimated)

Wave 1: λ=50ft, dir=28.6°, amp=0.4ft
  marching
    Run 1
      total       : 1184.8ms
      bounds      :    0.0ms
      march       :  679.6ms
      amplitude   :   35.8ms
      diffraction :   21.6ms
      decimate    :  441.9ms
      mesh        :    5.8ms
    Run 2
      total       : 1181.3ms
      bounds      :    0.0ms
      march       :  681.6ms
      amplitude   :   36.6ms
      diffraction :   21.6ms
      decimate    :  436.6ms
      mesh        :    4.9ms
    Run 3
      total       : 1191.1ms
      bounds      :    0.0ms
      march       :  689.8ms
      amplitude   :   36.8ms
      diffraction :   21.7ms
      decimate    :  441.7ms
      mesh        :    1.1ms
    Summary
┌─────────┬───────────────┬────────────┬────────────┬────────────┬────────────┐
│ (index) │ part          │ min        │ median     │ mean       │ max        │
├─────────┼───────────────┼────────────┼────────────┼────────────┼────────────┤
│ 0       │ 'total'       │ '1181.3ms' │ '1184.8ms' │ '1185.7ms' │ '1191.1ms' │
│ 1       │ 'bounds'      │ '0.0ms'    │ '0.0ms'    │ '0.0ms'    │ '0.0ms'    │
│ 2       │ 'march'       │ '679.6ms'  │ '681.6ms'  │ '683.7ms'  │ '689.8ms'  │
│ 3       │ 'amplitude'   │ '35.8ms'   │ '36.6ms'   │ '36.4ms'   │ '36.8ms'   │
│ 4       │ 'diffraction' │ '21.6ms'   │ '21.6ms'   │ '21.6ms'   │ '21.7ms'   │
│ 5       │ 'decimate'    │ '436.6ms'  │ '441.7ms'  │ '440.1ms'  │ '441.9ms'  │
│ 6       │ 'mesh'        │ '1.1ms'    │ '4.9ms'    │ '3.9ms'    │ '5.8ms'    │
└─────────┴───────────────┴────────────┴────────────┴────────────┴────────────┘
    Mesh counts
      vertices : 858,273 -> 42,126 (95.1% decimated)
      triangles: 1,706,043 -> 80,986 (95.3% decimated)