### PR TITLE
Add tree placement generation and loading system

### DIFF
--- a/bin/build-level
+++ b/bin/build-level
@@ -46,6 +46,7 @@ Usage:
   build-level build --region <slug>                            Run full pipeline + mesh build for a region
   build-level wave-mesh [--level <name>]                       Build wave mesh(es) only
   build-level wind-mesh [--level <name>]                       Build wind mesh(es) only
+  build-level trees [--level <name>]                           Generate tree positions only
   build-level extract [--region <slug> | --level <name>]       Extract terrain → .terrain.json
   build-level download [--region <slug> | --level <name>]      Download elevation tiles
   build-level build-grid [--region <slug> | --level <name>]    Build merged elevation grid
@@ -196,7 +197,7 @@ case "${1:-}" in
     echo "Usage: build-level completion zsh" >&2
     exit 2
     ;;
-  build|wave-mesh|wind-mesh|download|build-grid|extract|clean|validate|import )
+  build|wave-mesh|wind-mesh|trees|download|build-grid|extract|clean|validate|import )
     run_rust_cli "$@"
     ;;
   --* )

--- a/bin/generate-asset-types.ts
+++ b/bin/generate-asset-types.ts
@@ -25,6 +25,7 @@ const manifestFileTemplate = (
   jsonFiles: string[],
   wavemeshFiles: string[],
   windmeshFiles: string[],
+  treesFiles: string[],
   varName: (file: string) => string,
 ) =>
   /*ts*/ `
@@ -95,7 +96,14 @@ ${windmeshFiles
 };
 export type WindmeshName = keyof typeof windmeshes;
 
-export const RESOURCES = { sounds, images, fonts, levels, terrains, entityDefs, jsonBlobs, wavemeshes, windmeshes };
+const trees = {
+${treesFiles
+  .map((t) => /*ts*/ `  ${varName(t)}: "/assets/${t.replace(/^\.\//, "")}"`)
+  .join(",\n")}
+};
+export type TreesName = keyof typeof trees;
+
+export const RESOURCES = { sounds, images, fonts, levels, terrains, entityDefs, jsonBlobs, wavemeshes, windmeshes, trees };
 `.trimStart();
 
 /*
@@ -134,12 +142,13 @@ async function main() {
     terrain: "terrain",
     wavemesh: "wavemesh",
     windmesh: "windmesh",
+    trees: "trees",
   } as const;
   type FileExtension = keyof typeof extensionToType;
   type ResourceType = (typeof extensionToType)[FileExtension] | "res";
 
   /** Extensions served statically (no Parcel processing, no .d.ts needed). */
-  const staticExtensions = new Set(["terrain", "wavemesh", "windmesh"]);
+  const staticExtensions = new Set(["terrain", "wavemesh", "windmesh", "trees"]);
 
   const extensions = Object.keys(extensionToType);
   const extensionPattern = extensions.join("|");
@@ -236,6 +245,7 @@ async function main() {
     const jsonFiles: string[] = [];
     const wavemeshFiles: string[] = [];
     const windmeshFiles: string[] = [];
+    const treesFiles: string[] = [];
 
     for (const fileName of fileNames) {
       const parts = fileName.split(".");
@@ -288,6 +298,9 @@ async function main() {
         case "windmesh":
           windmeshFiles.push(relativePath);
           break;
+        case "trees":
+          treesFiles.push(relativePath);
+          break;
       }
     }
 
@@ -307,6 +320,7 @@ async function main() {
       jsonFiles,
       wavemeshFiles,
       windmeshFiles,
+      treesFiles,
       varName,
     );
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev-server": "tsx ./bin/dev-server.ts",
     "watch-manifest": "tsx ./bin/generate-asset-types.ts -d ./resources watch",
     "build": "parcel build src/index.html && npm run copy-static-assets",
-    "copy-static-assets": "mkdir -p dist/assets/levels && cp static/levels/*.terrain static/levels/*.wavemesh static/levels/*.windmesh dist/assets/levels/ 2>/dev/null || true",
+    "copy-static-assets": "mkdir -p dist/assets/levels && cp static/levels/*.terrain static/levels/*.wavemesh static/levels/*.windmesh static/levels/*.trees dist/assets/levels/ 2>/dev/null || true",
     "tsc": "tsc --noEmit",
     "tsc-watch": "tsc --noEmit --watch",
     "tsgo": "tsgo --noEmit",

--- a/pipeline/build-level/src/main.rs
+++ b/pipeline/build-level/src/main.rs
@@ -7,6 +7,7 @@ mod marching;
 mod region;
 mod segment_index;
 mod simplify;
+mod trees;
 mod validate;
 
 use std::fs;
@@ -49,6 +50,8 @@ enum Commands {
     WaveMesh,
     /// Build wind mesh (.windmesh) for level(s)
     WindMesh,
+    /// Generate tree positions (.trees) for level(s)
+    Trees,
     /// Extract terrain → .terrain.json
     Extract(CommonRegionArgs),
     /// Download elevation tiles
@@ -100,6 +103,7 @@ fn main() -> Result<()> {
         Some(Commands::Build(args)) => run_build(args.region.as_deref(), level_filter, &view),
         Some(Commands::WaveMesh) => run_wave_mesh(level_filter, &view),
         Some(Commands::WindMesh) => run_wind_mesh(level_filter, &view),
+        Some(Commands::Trees) => run_trees(level_filter, &view),
         Some(Commands::Extract(args)) => {
             let region = resolve_region_for_terrain_command(
                 "extract",
@@ -224,6 +228,28 @@ fn run_wind_mesh(level_filter: Option<&str>, view: &StepView) -> Result<()> {
     Ok(())
 }
 
+fn run_trees(level_filter: Option<&str>, view: &StepView) -> Result<()> {
+    let level_paths = resolve_level_paths(level_filter)?;
+    if level_paths.is_empty() {
+        view.info("No level files found.");
+        return Ok(());
+    }
+
+    view.info(format!(
+        "Generating trees for {} level(s)",
+        format_int(level_paths.len())
+    ));
+
+    for level_path in &level_paths {
+        let slug = level_slug_from_path(level_path);
+        view.header(&slug);
+        run_trees_for_level(level_path, &slug, &view.indented())?;
+    }
+
+    view.info("Done.");
+    Ok(())
+}
+
 fn resolve_level_paths(level_filter: Option<&str>) -> Result<Vec<PathBuf>> {
     if let Some(level_slug) = level_filter {
         return Ok(vec![resolve_level_file_for_slug(level_slug)?]);
@@ -325,8 +351,19 @@ fn run_wind_mesh_for_level(level_path: &Path, slug: &str, view: &StepView) -> Re
     Ok(())
 }
 
+fn run_trees_for_level(level_path: &Path, slug: &str, view: &StepView) -> Result<()> {
+    let output_path = region::trees_output_path(slug);
+    let inner = view.indented();
+    let _s = view.section("generate-trees");
+    trees::run_generate_trees(level_path, &output_path, &inner)?;
+    drop(_s);
+    Ok(())
+}
+
 fn run_all_meshes_for_level(level_path: &Path, slug: &str, view: &StepView) -> Result<()> {
     run_wave_mesh_for_level(level_path, slug, view)?;
+    // Generate trees before wind mesh so tree data is available for wind
+    run_trees_for_level(level_path, slug, view)?;
     run_wind_mesh_for_level(level_path, slug, view)?;
     Ok(())
 }
@@ -449,6 +486,7 @@ fn clean_region_outputs(slug: &str, view: &StepView) -> Result<CleanStats> {
     let terrain_path = terrain_output_path(slug);
     let wavemesh_path = region::wavemesh_output_path(slug);
     let windmesh_path = region::windmesh_output_path(slug);
+    let trees_path = region::trees_output_path(slug);
 
     view.info(format!("Region: {}", config.name));
 
@@ -466,6 +504,13 @@ fn clean_region_outputs(slug: &str, view: &StepView) -> Result<CleanStats> {
         &windmesh_path,
         &tiles_root,
         "windmesh file",
+        &mut stats,
+        view,
+    )?;
+    remove_generated_path(
+        &trees_path,
+        &tiles_root,
+        "trees file",
         &mut stats,
         view,
     )?;

--- a/pipeline/build-level/src/region.rs
+++ b/pipeline/build-level/src/region.rs
@@ -74,6 +74,11 @@ pub fn windmesh_output_path(slug: &str) -> PathBuf {
     repo_root().join(format!("static/levels/{}.windmesh", slug))
 }
 
+/// Convention-based path for a region's trees output file.
+pub fn trees_output_path(slug: &str) -> PathBuf {
+    repo_root().join(format!("static/levels/{}.trees", slug))
+}
+
 /// Convention-based path for a region's level file.
 pub fn level_path_for_slug(slug: &str) -> PathBuf {
     repo_root().join(format!("resources/levels/{}.level.json", slug))

--- a/pipeline/build-level/src/trees.rs
+++ b/pipeline/build-level/src/trees.rs
@@ -1,0 +1,71 @@
+//! Tree generation step for the build pipeline.
+
+use std::path::Path;
+
+use anyhow::{anyhow, Context, Result};
+use terrain_core::level::{build_terrain_data, parse_level_file, resolve_level_terrain};
+use terrain_core::step::StepView;
+use terrain_core::trees::{build_tree_buffer, generate_trees};
+
+/// Default seed for deterministic tree placement.
+const DEFAULT_SEED: u64 = 42;
+
+/// Generate trees for a level and write the binary `.trees` file.
+pub fn run_generate_trees(level_path: &Path, output_path: &Path, view: &StepView) -> Result<()> {
+    let level_path_str = level_path
+        .to_str()
+        .ok_or_else(|| anyhow!("Invalid level path"))?;
+
+    let terrain_data = view.try_run_step(
+        "Parsing level for tree generation",
+        || -> Result<_> {
+            let json_str = std::fs::read_to_string(level_path)
+                .with_context(|| format!("failed to read level file: {level_path_str}"))?;
+            let mut level_file = parse_level_file(&json_str)
+                .with_context(|| format!("failed to parse level JSON: {level_path_str}"))?;
+            resolve_level_terrain(&mut level_file, level_path)?;
+            Ok(build_terrain_data(&level_file))
+        },
+        |td, d| {
+            format!(
+                "Parsed level for trees: {}ms ({} contours)",
+                d.as_millis(),
+                td.contour_count,
+            )
+        },
+    )?;
+
+    let tree_data = view.run_step(
+        "Generating tree positions",
+        || generate_trees(&terrain_data, DEFAULT_SEED),
+        |td, d| {
+            format!(
+                "Generated {} trees ({}ms)",
+                td.positions.len(),
+                d.as_millis(),
+            )
+        },
+    );
+
+    view.try_run_step(
+        "Writing .trees file",
+        || -> Result<_> {
+            let buffer = build_tree_buffer(&tree_data);
+            let output_str = output_path.display().to_string();
+            std::fs::write(output_path, &buffer)
+                .with_context(|| format!("failed to write trees file: {output_str}"))?;
+            Ok(buffer)
+        },
+        |buffer, d| {
+            format!(
+                "Wrote {} ({:.1} KB, {} trees) in {}ms",
+                output_path.display(),
+                buffer.len() as f64 / 1024.0,
+                tree_data.positions.len(),
+                d.as_millis(),
+            )
+        },
+    )?;
+
+    Ok(())
+}

--- a/pipeline/terrain-core/src/lib.rs
+++ b/pipeline/terrain-core/src/lib.rs
@@ -2,3 +2,4 @@ pub mod humanize;
 pub mod level;
 pub mod step;
 pub mod terrain;
+pub mod trees;

--- a/pipeline/terrain-core/src/trees.rs
+++ b/pipeline/terrain-core/src/trees.rs
@@ -1,0 +1,129 @@
+//! Tree placement generation and binary .trees file writing.
+//!
+//! Algorithm: scatter pseudorandom candidate points across the terrain AABB,
+//! keep those whose terrain height falls within an elevation band.
+
+use crate::level::TerrainCPUData;
+use crate::terrain::{compute_terrain_height, parse_contours};
+
+// ── Configuration ────────────────────────────────────────────────────────────
+
+const NUM_CANDIDATES: usize = 1000;
+const MIN_ELEVATION: f64 = 10.0; // feet
+const MAX_ELEVATION: f64 = 1000.0; // feet
+
+// ── Output ───────────────────────────────────────────────────────────────────
+
+pub struct TreeData {
+    /// Flat list of (x, y) positions in world feet.
+    pub positions: Vec<[f32; 2]>,
+}
+
+// ── Binary file format ──────────────────────────────────────────────────────
+
+const MAGIC: u32 = 0x45455254; // "TREE" little-endian
+const VERSION: u16 = 1;
+const HEADER_BYTES: usize = 16;
+const BYTES_PER_TREE: usize = 8;
+
+/// Serialize tree positions into the binary `.trees` format.
+pub fn build_tree_buffer(data: &TreeData) -> Vec<u8> {
+    let tree_count = data.positions.len();
+    let total_size = HEADER_BYTES + tree_count * BYTES_PER_TREE;
+    let mut buf = vec![0u8; total_size];
+
+    // Header (16 bytes)
+    buf[0..4].copy_from_slice(&MAGIC.to_le_bytes());
+    buf[4..6].copy_from_slice(&VERSION.to_le_bytes());
+    // [6..8] reserved = 0
+    buf[8..12].copy_from_slice(&(tree_count as u32).to_le_bytes());
+    // [12..16] reserved = 0
+
+    // Tree data (8 bytes per tree)
+    for (i, pos) in data.positions.iter().enumerate() {
+        let offset = HEADER_BYTES + i * BYTES_PER_TREE;
+        buf[offset..offset + 4].copy_from_slice(&pos[0].to_le_bytes());
+        buf[offset + 4..offset + 8].copy_from_slice(&pos[1].to_le_bytes());
+    }
+
+    buf
+}
+
+// ── Simple PCG-style PRNG ───────────────────────────────────────────────────
+
+struct Rng {
+    state: u64,
+}
+
+impl Rng {
+    fn new(seed: u64) -> Self {
+        Self {
+            state: seed.wrapping_add(0x9E3779B97F4A7C15),
+        }
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.state = self.state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        let mut x = self.state;
+        x ^= x >> 30;
+        x = x.wrapping_mul(0xBF58476D1CE4E5B9);
+        x ^= x >> 27;
+        x = x.wrapping_mul(0x94D049BB133111EB);
+        x ^= x >> 31;
+        x
+    }
+
+    /// Returns a value in [0.0, 1.0).
+    fn next_f64(&mut self) -> f64 {
+        (self.next_u64() >> 11) as f64 / (1u64 << 53) as f64
+    }
+}
+
+// ── Generation ──────────────────────────────────────────────────────────────
+
+/// Generate tree positions by scattering random candidates across the terrain
+/// AABB and keeping those within the elevation band.
+pub fn generate_trees(terrain: &TerrainCPUData, seed: u64) -> TreeData {
+    let (contours, _lookup_grid) = parse_contours(terrain);
+
+    // Compute terrain AABB
+    let vert_count = terrain.vertex_data.len() / 2;
+    if vert_count == 0 {
+        return TreeData {
+            positions: Vec::new(),
+        };
+    }
+
+    let mut min_x = f64::INFINITY;
+    let mut min_y = f64::INFINITY;
+    let mut max_x = f64::NEG_INFINITY;
+    let mut max_y = f64::NEG_INFINITY;
+
+    for i in 0..vert_count {
+        let x = terrain.vertex_data[i * 2] as f64;
+        let y = terrain.vertex_data[i * 2 + 1] as f64;
+        min_x = min_x.min(x);
+        min_y = min_y.min(y);
+        max_x = max_x.max(x);
+        max_y = max_y.max(y);
+    }
+
+    let width = max_x - min_x;
+    let height = max_y - min_y;
+
+    let mut rng = Rng::new(seed);
+    let mut positions = Vec::new();
+
+    for _ in 0..NUM_CANDIDATES {
+        let x = min_x + rng.next_f64() * width;
+        let y = min_y + rng.next_f64() * height;
+
+        let h = compute_terrain_height(x, y, terrain, &contours);
+
+        if h >= MIN_ELEVATION && h <= MAX_ELEVATION {
+            positions.push([x as f32, y as f32]);
+        }
+    }
+
+    TreeData { positions }
+}

--- a/pipeline/wavemesh-builder/src/lib.rs
+++ b/pipeline/wavemesh-builder/src/lib.rs
@@ -337,6 +337,69 @@ pub fn build_windmesh_for_level_with_view(
         |_, d| format!("Built terrain data: {}ms", format_ms(d)),
     );
 
+    // Load tree data if a .trees file exists alongside the level
+    let trees_path = level_path.replace(".level.json", ".trees");
+    // Try static/levels/ path convention (used by build pipeline)
+    let trees_static_path = {
+        let p = std::path::Path::new(level_path);
+        let slug = p
+            .file_stem()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .replace(".level", "");
+        format!("static/levels/{}.trees", slug)
+    };
+    let _tree_data = if std::path::Path::new(&trees_static_path).exists() {
+        match std::fs::read(&trees_static_path) {
+            Ok(data) => {
+                let tree_count = if data.len() >= 16 {
+                    u32::from_le_bytes([data[8], data[9], data[10], data[11]]) as usize
+                } else {
+                    0
+                };
+                view.info(format!(
+                    "Loaded tree data: {} trees from {}",
+                    format_int(tree_count),
+                    short_path(&trees_static_path)
+                ));
+                Some(data)
+            }
+            Err(e) => {
+                view.info(format!(
+                    "Could not load tree data from {}: {}",
+                    trees_static_path, e
+                ));
+                None
+            }
+        }
+    } else if std::path::Path::new(&trees_path).exists() {
+        match std::fs::read(&trees_path) {
+            Ok(data) => {
+                let tree_count = if data.len() >= 16 {
+                    u32::from_le_bytes([data[8], data[9], data[10], data[11]]) as usize
+                } else {
+                    0
+                };
+                view.info(format!(
+                    "Loaded tree data: {} trees from {}",
+                    format_int(tree_count),
+                    short_path(&trees_path)
+                ));
+                Some(data)
+            }
+            Err(e) => {
+                view.info(format!(
+                    "Could not load tree data from {}: {}",
+                    trees_path, e
+                ));
+                None
+            }
+        }
+    } else {
+        view.info("No tree data available (wind mesh will not account for trees)".to_string());
+        None
+    };
+
     let wind_directions: Vec<f64> = wind_sources.iter().map(|s| s.direction).collect();
     let input_hash = windmesh_file::compute_wind_input_hash(&terrain_data, &wind_directions);
     view.info(format!(

--- a/resources/resources.ts
+++ b/resources/resources.ts
@@ -66,4 +66,9 @@ const windmeshes = {
 };
 export type WindmeshName = keyof typeof windmeshes;
 
-export const RESOURCES = { sounds, images, fonts, levels, terrains, entityDefs, jsonBlobs, wavemeshes, windmeshes };
+const trees = {
+
+};
+export type TreesName = keyof typeof trees;
+
+export const RESOURCES = { sounds, images, fonts, levels, terrains, entityDefs, jsonBlobs, wavemeshes, windmeshes, trees };

--- a/src/editor/io/LevelLoader.ts
+++ b/src/editor/io/LevelLoader.ts
@@ -6,9 +6,11 @@
  */
 
 import type { WavefrontMeshData } from "../../pipeline/mesh-building/MeshBuildTypes";
+import type { TreeFileData } from "../../pipeline/mesh-building/TreeFile";
 import type { WindMeshFileBundle } from "../../pipeline/mesh-building/WindmeshFile";
 import { loadWavemeshFromUrl } from "../../game/wave-physics/WavemeshLoader";
 import { loadWindmeshFromUrl } from "../../game/wind/WindmeshLoader";
+import { loadTreesFromUrl } from "../../game/trees/TreeLoader";
 import { RESOURCES, LevelName } from "../../../resources/resources";
 import {
   EditorLevelDefinition,
@@ -71,6 +73,7 @@ async function resolveTerrainReference(
 export interface LoadedLevel extends LevelData {
   wavemeshData: WavefrontMeshData[] | undefined;
   windmeshData: WindMeshFileBundle | undefined;
+  treeData: TreeFileData | undefined;
 }
 
 /**
@@ -121,7 +124,24 @@ export async function loadLevel(levelName: LevelName): Promise<LoadedLevel> {
     }
   }
 
-  return { ...levelData, wavemeshData, windmeshData };
+  let treeData: TreeFileData | undefined;
+  const treesUrl =
+    RESOURCES.trees[levelName as keyof typeof RESOURCES.trees];
+  if (treesUrl) {
+    try {
+      treeData = await loadTreesFromUrl(treesUrl);
+      console.log(
+        `[LevelLoader] Loaded tree data for "${levelName}" (${treeData.positions.length} trees)`,
+      );
+    } catch (e) {
+      console.error(
+        `[LevelLoader] Failed to load tree data for "${levelName}":`,
+        e,
+      );
+    }
+  }
+
+  return { ...levelData, wavemeshData, windmeshData, treeData };
 }
 
 /**

--- a/src/game/GameController.ts
+++ b/src/game/GameController.ts
@@ -1,6 +1,7 @@
 import { BaseEntity } from "../core/entity/BaseEntity";
 import { on } from "../core/entity/handler";
 import { ReactPreloader } from "../core/resources/Preloader";
+import type { TreeFileData } from "../pipeline/mesh-building/TreeFile";
 import { LevelName } from "../../resources/resources";
 import { loadLevel } from "../editor/io/LevelLoader";
 import { Boat } from "./boat/Boat";
@@ -33,8 +34,8 @@ let MENU_ZOOM: number = 2;
 //#tunable("Camera") { min: 1, max: 20 }
 let GAMEPLAY_ZOOM: number = 5;
 
-// Hardcoded tree positions per level (in world feet, on landmasses)
-const TREES_BY_LEVEL: Partial<Record<LevelName, [number, number][]>> = {
+// Fallback hardcoded tree positions for levels without a .trees file
+const FALLBACK_TREES: Partial<Record<LevelName, [number, number][]>> = {
   default: [
     [300, -200],
     [100, -440],
@@ -68,6 +69,7 @@ export class GameController extends BaseEntity {
   persistenceLevel = 100;
 
   private currentLevel: LevelName | null = null;
+  private treeData: TreeFileData | undefined;
 
   @on("add")
   onAdd() {
@@ -90,9 +92,10 @@ export class GameController extends BaseEntity {
     this.currentLevel = levelName;
     const initScreen = this.game.addEntity(new GameInitializingScreen());
 
-    // 1. Load level data (terrain + waves + wavemesh)
-    const { terrain, waves, wind, wavemeshData, windmeshData } =
+    // 1. Load level data (terrain + waves + wavemesh + trees)
+    const { terrain, waves, wind, wavemeshData, windmeshData, treeData } =
       await loadLevel(levelName);
+    this.treeData = treeData;
     this.game.addEntity(new TerrainResources(terrain));
     this.game.addEntity(new TerrainQueryManager());
 
@@ -146,10 +149,13 @@ export class GameController extends BaseEntity {
     this.game.addEntity(new WindParticles());
     this.game.addEntity(new WindSoundGenerator());
 
-    // Spawn trees on landmasses
-    const treePositions =
-      this.currentLevel != null ? TREES_BY_LEVEL[this.currentLevel] : undefined;
-    for (const [x, y] of treePositions ?? []) {
+    // Spawn trees on landmasses (prefer generated .trees file, fall back to hardcoded)
+    const treePositions: [number, number][] = this.treeData
+      ? this.treeData.positions
+      : (this.currentLevel != null
+          ? FALLBACK_TREES[this.currentLevel]
+          : undefined) ?? [];
+    for (const [x, y] of treePositions) {
       this.game.addEntity(new Tree(x, y));
     }
 

--- a/src/game/trees/TreeLoader.ts
+++ b/src/game/trees/TreeLoader.ts
@@ -1,0 +1,10 @@
+import { parseTreeBuffer, TreeFileData } from "../../pipeline/mesh-building/TreeFile";
+
+export async function loadTreesFromUrl(url: string): Promise<TreeFileData> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch trees: ${response.status} ${url}`);
+  }
+  const buffer = await response.arrayBuffer();
+  return parseTreeBuffer(buffer);
+}

--- a/src/pipeline/mesh-building/TreeFile.ts
+++ b/src/pipeline/mesh-building/TreeFile.ts
@@ -1,0 +1,64 @@
+/**
+ * Binary .trees file format for prebuilt tree position data.
+ *
+ * Format:
+ *   Header (16 bytes):
+ *     [0..3]   magic: "TREE" (ASCII LE) = 0x45455254
+ *     [4..5]   version: u16 = 1
+ *     [6..7]   reserved: u16 = 0
+ *     [8..11]  treeCount: u32
+ *     [12..15] reserved: u32 = 0
+ *
+ *   Tree data (8 bytes per tree):
+ *     x: f32 (world feet)
+ *     y: f32 (world feet)
+ */
+
+const MAGIC = 0x45455254; // "TREE" as little-endian u32
+const HEADER_BYTES = 16;
+const BYTES_PER_TREE = 8;
+
+export interface TreeFileData {
+  positions: [number, number][];
+}
+
+export function parseTreeBuffer(buffer: ArrayBuffer): TreeFileData {
+  const view = new DataView(buffer);
+
+  if (buffer.byteLength < HEADER_BYTES) {
+    throw new Error(
+      `Tree file too small: ${buffer.byteLength} bytes (need at least ${HEADER_BYTES})`,
+    );
+  }
+
+  const magic = view.getUint32(0, true);
+  if (magic !== MAGIC) {
+    throw new Error(
+      `Invalid tree file magic: 0x${magic.toString(16)} (expected 0x${MAGIC.toString(16)})`,
+    );
+  }
+
+  const version = view.getUint16(4, true);
+  if (version !== 1) {
+    throw new Error(`Unsupported tree file version: ${version}`);
+  }
+
+  const treeCount = view.getUint32(8, true);
+  const expectedSize = HEADER_BYTES + treeCount * BYTES_PER_TREE;
+  if (buffer.byteLength < expectedSize) {
+    throw new Error(
+      `Tree file truncated: ${buffer.byteLength} bytes (expected ${expectedSize} for ${treeCount} trees)`,
+    );
+  }
+
+  const positions: [number, number][] = new Array(treeCount);
+  for (let i = 0; i < treeCount; i++) {
+    const offset = HEADER_BYTES + i * BYTES_PER_TREE;
+    positions[i] = [
+      view.getFloat32(offset, true),
+      view.getFloat32(offset + 4, true),
+    ];
+  }
+
+  return { positions };
+}


### PR DESCRIPTION
## Summary
This PR adds a complete tree placement generation and loading system for levels. Trees are now procedurally generated based on terrain elevation bands, serialized to a binary `.trees` file format, and loaded into the game engine.

## Key Changes

**Tree Generation Pipeline (Rust)**
- Added `terrain-core/src/trees.rs` with tree placement algorithm that:
  - Scatters pseudorandom candidate points across terrain AABB
  - Filters candidates by elevation band (10–1000 feet)
  - Uses PCG-style PRNG for deterministic placement
  - Serializes positions to binary `.trees` format (16-byte header + 8 bytes per tree)
- Added `build-level/src/trees.rs` CLI command to generate `.trees` files for levels
- Integrated tree generation into build pipeline (runs before wind mesh generation)

**Binary File Format**
- Defined `.trees` format with magic number `0x45455254` ("TREE"), version 1, and tree count
- Implemented serialization in Rust and parsing in TypeScript
- Added `TreeFile.ts` parser with validation and error handling

**Game Integration**
- Added `TreeLoader.ts` to load `.trees` files from URLs
- Updated `LevelLoader.ts` to load tree data alongside level assets
- Modified `GameController.ts` to use generated tree data with fallback to hardcoded positions
- Trees now spawn from loaded `.trees` file when available

**Build System Updates**
- Added `trees` command to `build-level` CLI
- Integrated tree generation into full pipeline (`run_all_meshes_for_level`)
- Updated asset manifest generation to include `.trees` files
- Added tree file cleanup in region output cleaning
- Updated `region.rs` with `trees_output_path()` helper

**Wind Mesh Integration**
- `wavemesh-builder` now loads and logs tree data (preparation for future wind simulation)
- Supports both `static/levels/` and level-relative `.trees` file paths

## Implementation Details
- Tree generation is deterministic (seed = 42) for reproducible placement
- Elevation filtering uses terrain height computation via contour interpolation
- Binary format is little-endian for cross-platform compatibility
- Fallback hardcoded tree positions remain for levels without `.trees` files
- Tree data is optional; game functions correctly without it

https://claude.ai/code/session_013y3A3bVMoJzat7WvYGZdwp


Fixes #85 