### PR TITLE
Add polygon bounds support for terrain extraction

### DIFF
--- a/pipeline/build-level/src/build_grid.rs
+++ b/pipeline/build-level/src/build_grid.rs
@@ -15,13 +15,14 @@ pub fn run_build_grid(region_arg: Option<&str>, force: bool, view: &StepView) ->
     let slug = resolve_region(region_arg)?;
     let config = load_region_config(&slug)?;
 
+    let bbox = config.effective_bbox();
     view.info(format!("Region: {}", slug));
     view.info(format!(
         "BBOX: {:.4},{:.4} -> {:.4},{:.4}",
-        config.bbox.min_lat, config.bbox.min_lon, config.bbox.max_lat, config.bbox.max_lon
+        bbox.min_lat, bbox.min_lon, bbox.max_lat, bbox.max_lon
     ));
 
-    let local_tile_paths = list_local_tiles(&tiles_dir(&slug), &config.bbox)?;
+    let local_tile_paths = list_local_tiles(&tiles_dir(&slug), &bbox)?;
     if local_tile_paths.is_empty() {
         bail!(
             "No matching GeoTIFF files in {}. Run download step first.",
@@ -55,10 +56,10 @@ pub fn run_build_grid(region_arg: Option<&str>, force: bool, view: &StepView) ->
             cmd.arg("-t_srs")
                 .arg("EPSG:4326")
                 .arg("-te")
-                .arg(config.bbox.min_lon.to_string())
-                .arg(config.bbox.min_lat.to_string())
-                .arg(config.bbox.max_lon.to_string())
-                .arg(config.bbox.max_lat.to_string())
+                .arg(bbox.min_lon.to_string())
+                .arg(bbox.min_lat.to_string())
+                .arg(bbox.max_lon.to_string())
+                .arg(bbox.max_lat.to_string())
                 .arg("-overwrite");
 
             for path in &local_tile_paths {

--- a/pipeline/build-level/src/download.rs
+++ b/pipeline/build-level/src/download.rs
@@ -51,10 +51,11 @@ pub fn run_download(region_arg: Option<&str>, view: &StepView) -> Result<()> {
     let cache_dir = grid_cache_dir(&slug);
     let out_dir = tiles_dir(&slug);
 
+    let bbox = config.effective_bbox();
     view.info(format!("Region: {}", slug));
     view.info(format!(
         "BBOX: {:.4},{:.4} -> {:.4},{:.4}",
-        config.bbox.min_lat, config.bbox.min_lon, config.bbox.max_lat, config.bbox.max_lon
+        bbox.min_lat, bbox.min_lon, bbox.max_lat, bbox.max_lon
     ));
 
     let client = Client::builder()
@@ -66,7 +67,7 @@ pub fn run_download(region_arg: Option<&str>, view: &StepView) -> Result<()> {
         DataSourceConfig::Cudem { dataset_path } => download_cudem(
             &client,
             &dataset_path,
-            &config.bbox,
+            &bbox,
             &cache_dir,
             &out_dir,
             view,
@@ -85,7 +86,7 @@ pub fn run_download(region_arg: Option<&str>, view: &StepView) -> Result<()> {
             view,
         ),
         DataSourceConfig::EmodnetWcs { coverage_id } => {
-            download_emodnet_wcs(&client, &coverage_id, &config.bbox, &out_dir, view)
+            download_emodnet_wcs(&client, &coverage_id, &bbox, &out_dir, view)
         }
     }
 }

--- a/pipeline/build-level/src/extract.rs
+++ b/pipeline/build-level/src/extract.rs
@@ -9,7 +9,7 @@ use terrain_core::humanize::format_int;
 use terrain_core::step::{format_ms, StepView};
 
 use crate::constrained_simplify::constrained_simplify_closed_ring;
-use crate::geo::{bbox_center, lat_lon_to_feet, meters_to_feet};
+use crate::geo::{bbox_center, lat_lon_to_feet, meters_to_feet, point_in_latlon_polygon};
 use crate::marching::{build_block_index, build_closed_rings, march_contours, ScalarGrid};
 use crate::region::{
     display_path, grid_cache_dir, load_region_config, resolve_region, terrain_output_path,
@@ -70,7 +70,7 @@ pub fn run_extract(region_arg: Option<&str>, view: &StepView) -> Result<()> {
         );
     }
 
-    let loaded = load_merged_grid(&merged_path, view)?;
+    let mut loaded = load_merged_grid(&merged_path, view)?;
 
     view.info(format!("Region: {}", slug));
     view.info(format!(
@@ -82,9 +82,39 @@ pub fn run_extract(region_arg: Option<&str>, view: &StepView) -> Result<()> {
         format_int(config.min_points)
     ));
 
+    // When polygon bounds are specified, mask grid cells outside the polygon
+    // to DEFAULT_DEPTH so marching squares never generates contours there.
+    if let Some(ref bounds) = config.bounds {
+        let (masked_count, new_min, new_max) = view.run_step(
+            "Masking grid to polygon bounds",
+            || {
+                mask_grid_to_polygon(
+                    &mut loaded.grid,
+                    loaded.origin_lon,
+                    loaded.origin_lat,
+                    loaded.lon_step,
+                    loaded.lat_step,
+                    bounds,
+                )
+            },
+            |(masked, _, _), d| {
+                format!(
+                    "Masked {} cells outside polygon ({}ms)",
+                    format_int(*masked),
+                    format_ms(d)
+                )
+            },
+        );
+        if masked_count > 0 {
+            loaded.min_feet = new_min;
+            loaded.max_feet = new_max;
+        }
+    }
+
+    let effective_bbox = config.effective_bbox();
     let clamped_min = loaded.min_feet.max(DEFAULT_DEPTH);
     let levels = quantize_levels(clamped_min, loaded.max_feet, config.interval);
-    let (center_lat, center_lon) = bbox_center(&config.bbox);
+    let (center_lat, center_lon) = bbox_center(&effective_bbox);
 
     let bbox_min_lon = loaded.origin_lon - loaded.lon_step;
     let bbox_max_lat = loaded.origin_lat + loaded.lat_step;
@@ -683,4 +713,62 @@ fn round3(v: f64) -> f64 {
 
 fn round6(v: f64) -> f64 {
     (v * 1_000_000.0).round() / 1_000_000.0
+}
+
+/// Mask grid cells outside the polygon to DEFAULT_DEPTH.
+/// Returns (masked_count, new_min_feet, new_max_feet).
+fn mask_grid_to_polygon(
+    grid: &mut ScalarGrid,
+    origin_lon: f64,
+    origin_lat: f64,
+    lon_step: f64,
+    lat_step: f64,
+    polygon: &[[f64; 2]],
+) -> (usize, f64, f64) {
+    // The grid has a 1-cell padding border. Interior cells start at (1,1).
+    // Grid coords to lat/lon (matching load_merged_grid's transform):
+    //   lon = (origin_lon - lon_step) + gx * lon_step
+    //   lat = (origin_lat + lat_step) - gy * lat_step
+    let base_lon = origin_lon - lon_step;
+    let base_lat = origin_lat + lat_step;
+
+    let width = grid.width;
+    let height = grid.height;
+
+    use rayon::prelude::*;
+
+    let results: Vec<(usize, f64, f64)> = grid
+        .values
+        .par_chunks_mut(width)
+        .enumerate()
+        .map(|(gy, row)| {
+            let lat = base_lat - (gy as f64) * lat_step;
+            let mut masked = 0usize;
+            let mut row_min = f64::INFINITY;
+            let mut row_max = f64::NEG_INFINITY;
+            for gx in 0..width {
+                let lon = base_lon + (gx as f64) * lon_step;
+                if !point_in_latlon_polygon(lat, lon, polygon) {
+                    if row[gx] != DEFAULT_DEPTH {
+                        row[gx] = DEFAULT_DEPTH;
+                        masked += 1;
+                    }
+                }
+                row_min = row_min.min(row[gx]);
+                row_max = row_max.max(row[gx]);
+            }
+            (masked, row_min, row_max)
+        })
+        .collect();
+
+    let mut total_masked = 0usize;
+    let mut min_feet = f64::INFINITY;
+    let mut max_feet = f64::NEG_INFINITY;
+    for (m, rmin, rmax) in results {
+        total_masked += m;
+        min_feet = min_feet.min(rmin);
+        max_feet = max_feet.max(rmax);
+    }
+
+    (total_masked, min_feet, max_feet)
 }

--- a/pipeline/build-level/src/geo.rs
+++ b/pipeline/build-level/src/geo.rs
@@ -47,6 +47,25 @@ pub fn bbox_intersects(a: &BoundingBox, b: &BoundingBox) -> bool {
         || a.min_lon >= b.max_lon)
 }
 
+/// Ray-casting point-in-polygon test for lat/lon coordinates.
+/// Polygon vertices are `[lat, lon]` pairs forming a closed ring.
+pub fn point_in_latlon_polygon(lat: f64, lon: f64, polygon: &[[f64; 2]]) -> bool {
+    if polygon.len() < 3 {
+        return false;
+    }
+    let mut inside = false;
+    let mut j = polygon.len() - 1;
+    for i in 0..polygon.len() {
+        let (yi, xi) = (polygon[i][0], polygon[i][1]);
+        let (yj, xj) = (polygon[j][0], polygon[j][1]);
+        if (yi > lat) != (yj > lat) && lon < ((xj - xi) * (lat - yi) / (yj - yi)) + xi {
+            inside = !inside;
+        }
+        j = i;
+    }
+    inside
+}
+
 pub fn parse_tile_coverage_from_name(name: &str) -> Option<BoundingBox> {
     let re = regex::Regex::new(r"_([ns])(\d{1,2})x(\d{2})_([ew])(\d{1,3})x(\d{2})_").ok()?;
     let caps = re.captures(name)?;

--- a/pipeline/terrain-core/src/level.rs
+++ b/pipeline/terrain-core/src/level.rs
@@ -43,13 +43,20 @@ pub enum DataSourceConfig {
 }
 
 /// Region configuration for terrain extraction, embedded in the level file.
+///
+/// Bounds can be specified as either a rectangular `bbox` or a convex `bounds`
+/// polygon (array of `[lat, lon]` vertices). Exactly one must be present.
+/// When `bounds` is used, the pipeline computes the AABB from the polygon
+/// vertices for tile fetching and grid merging, then masks grid cells outside
+/// the polygon before contour extraction.
 #[derive(Debug, Clone, Deserialize)]
 pub struct RegionConfig {
     #[serde(rename = "datasetPath")]
     pub dataset_path: Option<String>,
     #[serde(rename = "dataSource")]
     pub data_source: Option<DataSourceConfig>,
-    pub bbox: BoundingBox,
+    pub bbox: Option<BoundingBox>,
+    pub bounds: Option<Vec<[f64; 2]>>,
     pub interval: f64,
     pub simplify: f64,
     pub scale: f64,
@@ -59,6 +66,35 @@ pub struct RegionConfig {
     pub min_points: usize,
     #[serde(rename = "flipY")]
     pub flip_y: bool,
+}
+
+impl RegionConfig {
+    /// Returns the effective axis-aligned bounding box, whether specified
+    /// directly via `bbox` or computed from the `bounds` polygon vertices.
+    pub fn effective_bbox(&self) -> BoundingBox {
+        if let Some(ref bbox) = self.bbox {
+            return bbox.clone();
+        }
+        if let Some(ref bounds) = self.bounds {
+            let mut min_lat = f64::INFINITY;
+            let mut max_lat = f64::NEG_INFINITY;
+            let mut min_lon = f64::INFINITY;
+            let mut max_lon = f64::NEG_INFINITY;
+            for &[lat, lon] in bounds {
+                min_lat = min_lat.min(lat);
+                max_lat = max_lat.max(lat);
+                min_lon = min_lon.min(lon);
+                max_lon = max_lon.max(lon);
+            }
+            return BoundingBox {
+                min_lat,
+                max_lat,
+                min_lon,
+                max_lon,
+            };
+        }
+        panic!("RegionConfig must have either bbox or bounds");
+    }
 }
 
 // ── Biome types ─────────────────────────────────────────────────────────────

--- a/src/editor/io/LevelFileFormat.ts
+++ b/src/editor/io/LevelFileFormat.ts
@@ -357,6 +357,9 @@ export interface BoundingBoxJSON {
 /**
  * Region configuration for terrain extraction from elevation data.
  * Embedded in the level file to define how terrain is built from geographic data.
+ *
+ * Bounds can be specified as either a rectangular `bbox` or a convex `bounds`
+ * polygon (array of `[lat, lon]` pairs). Exactly one must be present.
  */
 export interface RegionConfigJSON {
   datasetPath?: string;
@@ -364,7 +367,10 @@ export interface RegionConfigJSON {
     type: string;
     [key: string]: unknown;
   };
-  bbox: BoundingBoxJSON;
+  /** Axis-aligned bounding box. Mutually exclusive with `bounds`. */
+  bbox?: BoundingBoxJSON;
+  /** Convex polygon as `[lat, lon]` vertices. Mutually exclusive with `bbox`. */
+  bounds?: [number, number][];
   interval: number;
   simplify: number;
   scale: number;


### PR DESCRIPTION
## Summary
This PR adds support for specifying terrain extraction bounds as a convex polygon in addition to the existing axis-aligned bounding box. When a polygon is specified, the pipeline masks grid cells outside the polygon before contour extraction to prevent unwanted contours in excluded areas.

## Key Changes

- **RegionConfig schema update**: Made `bbox` optional and added new `bounds` field for polygon vertices as `[lat, lon]` pairs. Exactly one must be present.
  - Added `effective_bbox()` method to compute axis-aligned bounding box from polygon vertices when needed for tile fetching and grid merging

- **Grid masking implementation**: Added `mask_grid_to_polygon()` function that:
  - Uses ray-casting point-in-polygon test to identify cells outside the polygon
  - Sets out-of-polygon cells to `DEFAULT_DEPTH` to prevent marching squares from generating contours there
  - Recalculates min/max elevation values after masking
  - Uses parallel processing (rayon) for performance on large grids

- **Point-in-polygon utility**: Implemented `point_in_latlon_polygon()` using standard ray-casting algorithm for lat/lon coordinates

- **Pipeline integration**: Updated `extract.rs`, `build_grid.rs`, and `download.rs` to use `effective_bbox()` for all tile operations while applying polygon masking only during contour extraction

- **TypeScript types**: Updated `RegionConfigJSON` interface to reflect the new optional `bbox` and `bounds` fields with documentation

## Implementation Details

- The polygon masking step runs after grid merging but before contour extraction, ensuring the grid's min/max values are recalculated to reflect only the masked region
- Grid coordinates are properly transformed to lat/lon using the same logic as grid loading
- The 1-cell padding border in the grid is preserved during masking
- Parallel processing ensures efficient masking of large grids

https://claude.ai/code/session_01UFtFkfjJucALr8FXNhNeiJ

closes issue #94 