### PR TITLE
Add boat definition editor

### DIFF
--- a/bin/dev-server.ts
+++ b/bin/dev-server.ts
@@ -20,6 +20,7 @@ const parcel = spawn(
     String(PARCEL_PORT),
     "src/index.html",
     "src/editor.html",
+    "src/boat-editor.html",
   ],
   {
     stdio: "inherit",

--- a/plans/boat-editor.md
+++ b/plans/boat-editor.md
@@ -1,0 +1,187 @@
+# Boat Definition Editor
+
+Dev tool for authoring and tuning `BoatConfig` objects. Standalone page like the terrain editor (`src/boat-editor.html`), reusing the game engine for rendering.
+
+## Two Phases
+
+### Phase 1: Config Editor + 3D Preview
+
+Edit numeric config values with sliders/inputs, see the boat update live in a 3D orbit view. This is the core tool — useful immediately for tuning hull shapes, sail geometry, and rigging layout.
+
+### Phase 2: Physics Debugger
+
+Run the boat physics in the editor with simulated wind/water. Step through individual ticks and visualize forces (lift, drag, righting moment, buoyancy) as arrows overlaid on the boat. This is the tool for making the physics *feel* right, but it's significantly more complex since it needs to run the full physics loop, buoyancy system, and sail simulation standalone.
+
+---
+
+## Phase 1: Config Editor + 3D Preview
+
+### Architecture
+
+Follow the terrain editor pattern (Command + Listener):
+
+```
+BoatEditorController (BaseEntity)
+├── BoatEditorDocument         — BoatConfig state, undo/redo, dirty tracking
+├── BoatEditorCameraController — orbit via pitch/roll, zoom, preset views
+├── BoatPreviewEntity          — renders the boat from the document's config
+├── BoatEditorUI               — property panels, file I/O buttons
+└── WaterPlaneEntity           — flat water surface for reference
+```
+
+### 3D Orbit Camera
+
+The tilt projection system already gives us 3D-looking rendering by feeding pitch/roll into `TiltTransform`. An "orbit camera" just means letting the user control those angles directly:
+
+- **Drag to orbit**: mouse drag → pitch and yaw (mapped to the tilt transform angles)
+- **Scroll to zoom**: camera zoom
+- **Preset views**: buttons for "Top", "Side", "Bow", "3/4" that animate to specific angle combos
+- No actual 3D camera needed — just controlling the inputs to the existing projection
+
+The boat sits on a flat shaded water plane so you can see the waterline, draft, and freeboard.
+
+### Property Panels
+
+One collapsible panel per `BoatConfig` section. Each property is a labeled slider (with min/max/step) or number input. Changing a value creates an `EditPropertyCommand` for undo/redo.
+
+| Panel | Key Properties |
+|-------|---------------|
+| **Hull** | mass, draft, deckHeight, skinFrictionCoefficient, colors |
+| **Hull Shape** | vertex editor (see below) |
+| **Keel** | draft, chord, color |
+| **Rudder** | position, length, draft, chord, maxSteerAngle |
+| **Rig** | mastPosition, boomLength, boomMass |
+| **Mainsail** | liftScale, dragScale, optimalAngle, numNodes, sailHeight |
+| **Jib** | sail params + forestay attachment |
+| **Sheets** | boomAttachRatio, min/maxLength, trimSpeed |
+| **Tilt/Buoyancy** | inertia, damping, righting moment, max angles, zHeights |
+| **Anchor** | bowAttachPoint, maxRodeLength, mass, drag |
+| **Bilge/Damage** | thresholds, repair rates |
+
+### Hull Shape Editing
+
+The hull currently has three hand-placed vertex rings (deck, waterline, bottom). Two approaches worth considering — could support both:
+
+**A) Direct vertex editing (current model)**
+- Top-down view shows the three rings as draggable points, color-coded
+- Enforce port/starboard symmetry (edit one side, mirror to the other)
+- Good for fine-tuning weird shapes
+
+**B) Parametric hull generation (new)**
+- Define hull from parameters: length, beam, bow shape (sharp→blunt), stern shape, rocker, deadrise angle
+- Generate all three rings procedurally
+- Much easier to explore the design space — you're tweaking 6-8 meaningful params instead of placing 30+ vertices
+- Can still allow manual vertex overrides on top
+
+Parametric feels like the better default for a dev tool. You'd define a hull generator function:
+
+```typescript
+function generateHullVertices(params: HullShapeParams): {
+  vertices: V2d[];        // deck ring
+  waterlineVertices: V2d[];
+  bottomVertices: V2d[];
+}
+```
+
+Where `HullShapeParams` might be:
+- `length` — overall length
+- `beam` — max width
+- `bowFineness` — 0 (blunt) to 1 (sharp/pointy)
+- `sternFineness` — 0 (transom) to 1 (double-ender)
+- `bowRocker` — upward curve of the bow
+- `deadriseAngle` — V-shape of the bottom
+- `waterlineRatio` — how much narrower the waterline is than the deck
+- `bottomRatio` — how much narrower the bottom is than the waterline
+- `vertexCount` — resolution
+
+This could live in the game code too (not just the editor), so configs could store either explicit vertices or parametric params.
+
+### Visual Overlays
+
+Static indicators that update live as you edit values:
+
+- **Waterline**: the water plane intersection, always visible
+- **Center of gravity**: dot on the boat (derived from mass distribution + keel weight)
+- **Draft line**: side view showing how deep the keel/rudder extend
+- **Measurements**: length, beam, freeboard, draft as labeled dimensions
+- **Theoretical hull speed**: `1.34 × √(waterline length in ft)` displayed as a number
+
+### File I/O
+
+- **Load preset**: dropdown of existing configs (StarterDinghy, StarterBoat, etc.)
+- **Export JSON**: serialize the full `BoatConfig` to a JSON file
+- **Export TypeScript**: generate a `const myBoat: BoatConfig = { ... }` file
+- **Import JSON**: load a previously saved config
+- Use File System Access API like the terrain editor, with IndexedDB fallback for file handles
+
+### Undo/Redo
+
+Same Command pattern as terrain editor:
+
+```typescript
+interface BoatEditorCommand {
+  execute(): void;
+  undo(): void;
+  description: string;  // "Change hull mass to 450"
+}
+```
+
+Slider drags should coalesce — dragging a slider from 400→500 is one undo step, not 100 steps.
+
+---
+
+## Phase 2: Physics Debugger (Future)
+
+This is substantially more complex — needs the physics loop, buoyancy, sail sim, wind, and water surface running in an isolated/controllable way.
+
+### Core Idea
+
+Run the boat in a controlled physics sandbox where you can:
+- Set wind speed/direction with a dial
+- Play/pause/step the simulation
+- Step forward one tick at a time (1/120s)
+- See force vectors overlaid on the boat at each tick
+
+### Force Visualization
+
+At each tick, capture and render as colored arrows:
+- **Sail forces** (lift + drag per sail) — applied at center of effort
+- **Hydrodynamic forces** (keel lift/drag, rudder lift/drag, hull drag) — at their application points
+- **Buoyancy forces** — at each buoyancy sample point
+- **Righting moment** — as a torque arc
+- **Net force + torque** — summary arrow at center of mass
+
+### Stepping Interface
+
+- Play/pause button
+- Step forward 1 tick / 10 ticks / 100 ticks
+- Speed slider (0.1x to 10x)
+- Timeline scrubber showing recent history (last N ticks), letting you scrub back to see what happened
+- Each tick's state (position, velocity, forces) logged to a ring buffer
+
+### What Makes This Hard
+
+- Need to instantiate boat physics without the full game world (or with a minimal stub world)
+- Buoyancy needs water surface data — either fake a flat surface or run the water sim too
+- Sail cloth sim needs wind field — simplest to use uniform wind
+- Force capture requires instrumenting the physics code to record intermediate values that are currently computed and immediately consumed
+- The timeline/scrubber means storing snapshots of state
+
+### Possible Simplification
+
+Start with just "play with uniform wind + flat water" and a force overlay — no stepping, no timeline. That's already useful for tuning. The step debugger can come later as the physics get more complex.
+
+---
+
+## Implementation Order
+
+1. **Standalone page scaffolding** — `src/boat-editor.html`, entry point, minimal Game init
+2. **BoatEditorDocument** — wraps a `BoatConfig` with undo/redo
+3. **BoatPreviewEntity** — renders a boat from a config (statically, no physics)
+4. **Orbit camera** — pitch/yaw control via mouse drag on tilt transform
+5. **Property panels** — one panel per config section, wired to document commands
+6. **Hull shape generator** — parametric hull from ~8 params
+7. **Visual overlays** — waterline, measurements, center of gravity
+8. **File I/O** — load presets, export/import JSON and TypeScript
+9. *(Phase 2)* Physics sandbox with force visualization
+10. *(Phase 2)* Tick stepping and timeline

--- a/src/boat-editor.html
+++ b/src/boat-editor.html
@@ -1,0 +1,19 @@
+<html>
+  <head>
+    <title>Boat Editor - Tack &amp; Trim</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        background: #1a1a2e;
+        overflow: hidden;
+      }
+    </style>
+    <link rel="shortcut icon" href="../resources/images/favicon.png" />
+  </head>
+
+  <body>
+    <script src="./boat-editor/BoatEditorMain.ts" type="module"></script>
+  </body>
+</html>

--- a/src/boat-editor/BoatEditorCameraController.ts
+++ b/src/boat-editor/BoatEditorCameraController.ts
@@ -1,0 +1,143 @@
+/**
+ * Orbit-style camera for the boat editor.
+ *
+ * Uses the game's tilt projection to simulate 3D orbiting:
+ * - Left drag: orbit (adjust yaw and pitch)
+ * - Middle drag / Space+drag: pan
+ * - Scroll: zoom
+ * - Preset buttons can animate to specific angles.
+ */
+
+import { BaseEntity } from "../core/entity/BaseEntity";
+import { on } from "../core/entity/handler";
+import { clamp, lerp } from "../core/util/MathUtil";
+
+const MIN_ZOOM = 0.5;
+const MAX_ZOOM = 20;
+const ORBIT_SENSITIVITY = 0.008;
+const PAN_SENSITIVITY = 1.0;
+const ZOOM_FACTOR = 1.08;
+
+export class BoatEditorCameraController extends BaseEntity {
+  /** Current orbit angles (yaw = heading, pitch = elevation). */
+  yaw = Math.PI * 0.15;
+  pitch = 0.6;
+
+  private targetZoom = 6;
+  private isPanning = false;
+  private isOrbiting = false;
+  private lastMouse = { x: 0, y: 0 };
+  private spaceDown = false;
+
+  @on("add")
+  onAdd() {
+    this.game!.camera.z = this.targetZoom;
+
+    const canvas = this.game!.renderer.canvas;
+    canvas.addEventListener("mousedown", this.handleMouseDown);
+    canvas.addEventListener("wheel", this.handleWheel, { passive: false });
+    window.addEventListener("mousemove", this.handleMouseMove);
+    window.addEventListener("mouseup", this.handleMouseUp);
+    window.addEventListener("keydown", this.handleKeyDown);
+    window.addEventListener("keyup", this.handleKeyUp);
+  }
+
+  @on("destroy")
+  onDestroy() {
+    const canvas = this.game!.renderer.canvas;
+    canvas.removeEventListener("mousedown", this.handleMouseDown);
+    canvas.removeEventListener("wheel", this.handleWheel);
+    window.removeEventListener("mousemove", this.handleMouseMove);
+    window.removeEventListener("mouseup", this.handleMouseUp);
+    window.removeEventListener("keydown", this.handleKeyDown);
+    window.removeEventListener("keyup", this.handleKeyUp);
+  }
+
+  @on("tick")
+  onTick() {
+    const cam = this.game!.camera;
+    cam.z = lerp(cam.z, this.targetZoom, 0.15);
+  }
+
+  setPreset(name: "top" | "side" | "bow" | "quarter") {
+    switch (name) {
+      case "top":
+        this.yaw = 0;
+        this.pitch = 0;
+        break;
+      case "side":
+        this.yaw = 0;
+        this.pitch = Math.PI * 0.4;
+        break;
+      case "bow":
+        this.yaw = Math.PI * 0.5;
+        this.pitch = Math.PI * 0.25;
+        break;
+      case "quarter":
+        this.yaw = Math.PI * 0.15;
+        this.pitch = 0.6;
+        break;
+    }
+  }
+
+  private handleMouseDown = (e: MouseEvent) => {
+    this.lastMouse = { x: e.clientX, y: e.clientY };
+
+    if (e.button === 1 || (e.button === 0 && this.spaceDown)) {
+      this.isPanning = true;
+      e.preventDefault();
+    } else if (e.button === 0) {
+      this.isOrbiting = true;
+      e.preventDefault();
+    }
+  };
+
+  private handleMouseMove = (e: MouseEvent) => {
+    const dx = e.clientX - this.lastMouse.x;
+    const dy = e.clientY - this.lastMouse.y;
+    this.lastMouse = { x: e.clientX, y: e.clientY };
+
+    if (this.isOrbiting) {
+      this.yaw += dx * ORBIT_SENSITIVITY;
+      this.pitch = clamp(
+        this.pitch - dy * ORBIT_SENSITIVITY,
+        0,
+        Math.PI * 0.48,
+      );
+    } else if (this.isPanning) {
+      const cam = this.game!.camera;
+      const scale = PAN_SENSITIVITY / cam.z;
+      cam.setPosition(
+        cam.position[0] - dx * scale,
+        cam.position[1] - dy * scale,
+      );
+    }
+  };
+
+  private handleMouseUp = (e: MouseEvent) => {
+    if (e.button === 0) {
+      this.isOrbiting = false;
+      this.isPanning = false;
+    }
+    if (e.button === 1) {
+      this.isPanning = false;
+    }
+  };
+
+  private handleWheel = (e: WheelEvent) => {
+    e.preventDefault();
+    if (e.deltaY < 0) {
+      this.targetZoom = Math.min(this.targetZoom * ZOOM_FACTOR, MAX_ZOOM);
+    } else {
+      this.targetZoom = Math.max(this.targetZoom / ZOOM_FACTOR, MIN_ZOOM);
+    }
+  };
+
+  private handleKeyDown = (e: KeyboardEvent) => {
+    if (e.code === "Space") this.spaceDown = true;
+  };
+
+  private handleKeyUp = (e: KeyboardEvent) => {
+    if (e.code === "Space") this.spaceDown = false;
+  };
+}

--- a/src/boat-editor/BoatEditorController.ts
+++ b/src/boat-editor/BoatEditorController.ts
@@ -1,0 +1,130 @@
+/**
+ * Main orchestrator for the boat editor.
+ * Creates and wires up the document, camera, preview renderer, and UI.
+ */
+
+import { BaseEntity } from "../core/entity/BaseEntity";
+import { on } from "../core/entity/handler";
+import {
+  BoatConfig,
+  StarterDinghy,
+  StarterBoat,
+} from "../game/boat/BoatConfig";
+import { BoatEditorDocument, BoatDocumentListener } from "./BoatEditorDocument";
+import { BoatEditorCameraController } from "./BoatEditorCameraController";
+import { BoatPreviewRenderer } from "./BoatPreviewRenderer";
+import { BoatEditorUI } from "./BoatEditorUI";
+
+export const BOAT_PRESETS: Record<string, BoatConfig> = {
+  "Starter Dinghy": StarterDinghy,
+  "Starter Boat": StarterBoat,
+};
+
+export class BoatEditorController
+  extends BaseEntity
+  implements BoatDocumentListener
+{
+  readonly document: BoatEditorDocument;
+  private camera!: BoatEditorCameraController;
+  private preview!: BoatPreviewRenderer;
+  private ui!: BoatEditorUI;
+
+  constructor() {
+    super();
+    this.document = new BoatEditorDocument(StarterDinghy);
+    this.document.addListener(this);
+  }
+
+  @on("add")
+  onAdd() {
+    this.camera = this.game!.addEntity(new BoatEditorCameraController());
+    this.preview = this.game!.addEntity(
+      new BoatPreviewRenderer(this.document.config, this.camera),
+    );
+    this.ui = this.game!.addEntity(new BoatEditorUI(this));
+
+    window.addEventListener("keydown", this.handleKeyDown);
+    this.updateTitle();
+  }
+
+  @on("destroy")
+  onDestroy() {
+    window.removeEventListener("keydown", this.handleKeyDown);
+    this.document.removeListener(this);
+  }
+
+  // --- DocumentListener ---
+
+  onConfigChanged(): void {
+    this.preview.setConfig(this.document.config);
+  }
+
+  onDirtyChanged(): void {
+    this.updateTitle();
+  }
+
+  // --- Preset loading ---
+
+  loadPreset(name: string): void {
+    const preset = BOAT_PRESETS[name];
+    if (preset) {
+      this.document.loadConfig(preset);
+    }
+  }
+
+  // --- Export ---
+
+  exportJSON(): void {
+    const json = JSON.stringify(this.document.config, null, 2);
+    const blob = new Blob([json], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "boat-config.json";
+    a.click();
+    URL.revokeObjectURL(url);
+    this.document.markSaved();
+  }
+
+  async importJSON(): Promise<void> {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.accept = ".json";
+    input.onchange = async () => {
+      const file = input.files?.[0];
+      if (!file) return;
+      const text = await file.text();
+      const config = JSON.parse(text) as BoatConfig;
+      this.document.loadConfig(config);
+    };
+    input.click();
+  }
+
+  // --- Keyboard shortcuts ---
+
+  private handleKeyDown = (e: KeyboardEvent) => {
+    const mod = e.metaKey || e.ctrlKey;
+
+    if (mod && e.key === "z" && !e.shiftKey) {
+      e.preventDefault();
+      this.document.undo();
+    } else if (mod && e.key === "z" && e.shiftKey) {
+      e.preventDefault();
+      this.document.redo();
+    } else if (mod && e.key === "y") {
+      e.preventDefault();
+      this.document.redo();
+    } else if (mod && e.key === "s") {
+      e.preventDefault();
+      this.exportJSON();
+    } else if (mod && e.key === "o") {
+      e.preventDefault();
+      this.importJSON();
+    }
+  };
+
+  private updateTitle(): void {
+    const dirty = this.document.isDirty ? " *" : "";
+    document.title = `Boat Editor${dirty} - Tack & Trim`;
+  }
+}

--- a/src/boat-editor/BoatEditorDocument.ts
+++ b/src/boat-editor/BoatEditorDocument.ts
@@ -1,0 +1,193 @@
+/**
+ * State management for the boat editor.
+ * Wraps a BoatConfig with undo/redo via the Command pattern.
+ */
+
+import { BoatConfig, StarterDinghy } from "../game/boat/BoatConfig";
+
+// ============================================
+// Command Pattern
+// ============================================
+
+export interface BoatEditorCommand {
+  execute(): void;
+  undo(): void;
+  readonly description: string;
+}
+
+// ============================================
+// Listener
+// ============================================
+
+export interface BoatDocumentListener {
+  onConfigChanged(): void;
+  onDirtyChanged(isDirty: boolean): void;
+}
+
+// ============================================
+// Document
+// ============================================
+
+export class BoatEditorDocument {
+  private _config: BoatConfig;
+  private _savedConfig: BoatConfig; // snapshot at last save
+  private undoStack: BoatEditorCommand[] = [];
+  private redoStack: BoatEditorCommand[] = [];
+  private listeners: BoatDocumentListener[] = [];
+
+  constructor(config?: BoatConfig) {
+    this._config = config ?? StarterDinghy;
+    this._savedConfig = jsonClone(this._config);
+  }
+
+  // --- Config access ---
+
+  get config(): BoatConfig {
+    return this._config;
+  }
+
+  get isDirty(): boolean {
+    return JSON.stringify(this._config) !== JSON.stringify(this._savedConfig);
+  }
+
+  markSaved(): void {
+    this._savedConfig = jsonClone(this._config);
+    this.notifyDirtyChanged();
+  }
+
+  // --- Undo/Redo ---
+
+  get canUndo(): boolean {
+    return this.undoStack.length > 0;
+  }
+
+  get canRedo(): boolean {
+    return this.redoStack.length > 0;
+  }
+
+  executeCommand(cmd: BoatEditorCommand): void {
+    cmd.execute();
+    this.undoStack.push(cmd);
+    this.redoStack.length = 0;
+    this.notifyConfigChanged();
+  }
+
+  undo(): void {
+    const cmd = this.undoStack.pop();
+    if (cmd) {
+      cmd.undo();
+      this.redoStack.push(cmd);
+      this.notifyConfigChanged();
+    }
+  }
+
+  redo(): void {
+    const cmd = this.redoStack.pop();
+    if (cmd) {
+      cmd.execute();
+      this.undoStack.push(cmd);
+      this.notifyConfigChanged();
+    }
+  }
+
+  // --- Load ---
+
+  loadConfig(config: BoatConfig): void {
+    this._config = jsonClone(config);
+    this._savedConfig = jsonClone(config);
+    this.undoStack.length = 0;
+    this.redoStack.length = 0;
+    this.notifyConfigChanged();
+    this.notifyDirtyChanged();
+  }
+
+  // --- Listeners ---
+
+  addListener(listener: BoatDocumentListener): void {
+    this.listeners.push(listener);
+  }
+
+  removeListener(listener: BoatDocumentListener): void {
+    const i = this.listeners.indexOf(listener);
+    if (i >= 0) this.listeners.splice(i, 1);
+  }
+
+  private notifyConfigChanged(): void {
+    for (const l of this.listeners) l.onConfigChanged();
+    this.notifyDirtyChanged();
+  }
+
+  private notifyDirtyChanged(): void {
+    const dirty = this.isDirty;
+    for (const l of this.listeners) l.onDirtyChanged(dirty);
+  }
+}
+
+// ============================================
+// Commands
+// ============================================
+
+/**
+ * Generic command for setting a single property at a given path in the config.
+ * The path is a dot-separated string like "hull.mass" or "rudder.maxSteerAngle".
+ */
+export class SetPropertyCommand implements BoatEditorCommand {
+  private oldValue: unknown;
+  readonly description: string;
+
+  constructor(
+    private doc: BoatEditorDocument,
+    private path: string,
+    private newValue: unknown,
+  ) {
+    this.oldValue = getNestedValue(doc.config, path);
+    const shortPath = path.split(".").slice(-1)[0];
+    this.description = `Set ${shortPath} to ${newValue}`;
+  }
+
+  execute(): void {
+    setNestedValue(
+      this.doc.config as unknown as Record<string, unknown>,
+      this.path,
+      this.newValue,
+    );
+  }
+
+  undo(): void {
+    setNestedValue(
+      this.doc.config as unknown as Record<string, unknown>,
+      this.path,
+      this.oldValue,
+    );
+  }
+}
+
+// --- Helpers ---
+
+function getNestedValue(obj: unknown, path: string): unknown {
+  const keys = path.split(".");
+  let current: unknown = obj;
+  for (const key of keys) {
+    if (current == null || typeof current !== "object") return undefined;
+    current = (current as Record<string, unknown>)[key];
+  }
+  return current;
+}
+
+function setNestedValue(
+  obj: Record<string, unknown>,
+  path: string,
+  value: unknown,
+): void {
+  const keys = path.split(".");
+  let current: Record<string, unknown> = obj;
+  for (let i = 0; i < keys.length - 1; i++) {
+    current = current[keys[i]] as Record<string, unknown>;
+  }
+  current[keys[keys.length - 1]] = value;
+}
+
+/** JSON round-trip clone. Loses V2d prototypes but that's fine for snapshots. */
+function jsonClone(obj: BoatConfig): BoatConfig {
+  return JSON.parse(JSON.stringify(obj));
+}

--- a/src/boat-editor/BoatEditorMain.ts
+++ b/src/boat-editor/BoatEditorMain.ts
@@ -1,0 +1,57 @@
+/**
+ * Boat editor entry point.
+ *
+ * Initializes the game engine for the boat definition editor and loads
+ * the BoatEditorController to manage the editing session.
+ */
+
+import { Game } from "../core/Game";
+import "../fonts.css";
+import { registerManifestFonts } from "../core/resources/fonts";
+import { RESOURCES } from "../../resources/resources";
+import { BoatEditorController } from "./BoatEditorController";
+
+interface BoatEditorDebug {
+  game?: Game;
+  editor?: BoatEditorController;
+}
+
+async function main() {
+  await registerManifestFonts(RESOURCES.fonts);
+
+  const game = new Game({ ticksPerSecond: 120 });
+
+  await game.init({
+    rendererOptions: {
+      backgroundColor: 0x1a1a2e,
+    },
+  });
+
+  const debug: BoatEditorDebug = { game };
+  (
+    window as unknown as { BOAT_EDITOR_DEBUG: BoatEditorDebug }
+  ).BOAT_EDITOR_DEBUG = debug;
+
+  const editor = game.addEntity(new BoatEditorController());
+  debug.editor = editor;
+
+  window.addEventListener("beforeunload", (e) => {
+    if (debug.editor?.document.isDirty) {
+      e.preventDefault();
+    }
+    game.destroy();
+  });
+
+  console.log(
+    "%cBoat Editor Loaded",
+    "color: #44aa44; font-weight: bold; font-size: 14px",
+  );
+  console.log("Controls:");
+  console.log("  Orbit: Left-drag");
+  console.log("  Pan: Middle-drag or Space+drag");
+  console.log("  Zoom: Scroll wheel");
+  console.log("  Undo: Ctrl/Cmd+Z");
+  console.log("  Redo: Ctrl/Cmd+Shift+Z or Ctrl/Cmd+Y");
+}
+
+window.addEventListener("load", main);

--- a/src/boat-editor/BoatEditorUI.ts
+++ b/src/boat-editor/BoatEditorUI.ts
@@ -1,0 +1,23 @@
+/**
+ * Boat editor UI entity.
+ * Renders toolbar and property panels using Preact.
+ */
+
+import { ReactEntity } from "../core/ReactEntity";
+import type { BoatEditorController } from "./BoatEditorController";
+import { BoatEditorToolbar } from "./ui/BoatEditorToolbar";
+import { BoatPropertyPanels } from "./ui/BoatPropertyPanels";
+import { h, Fragment } from "preact";
+
+export class BoatEditorUI extends ReactEntity {
+  constructor(private controller: BoatEditorController) {
+    super(() => {
+      return h(
+        Fragment,
+        null,
+        h(BoatEditorToolbar, { controller: this.controller }),
+        h(BoatPropertyPanels, { controller: this.controller }),
+      );
+    }, true);
+  }
+}

--- a/src/boat-editor/BoatPreviewRenderer.ts
+++ b/src/boat-editor/BoatPreviewRenderer.ts
@@ -1,0 +1,331 @@
+/**
+ * Renders a static boat preview from a BoatConfig.
+ * No physics, no simulation — just the structural geometry.
+ */
+
+import { BaseEntity } from "../core/entity/BaseEntity";
+import { on } from "../core/entity/handler";
+import type { Draw } from "../core/graphics/Draw";
+import { earClipTriangulate } from "../core/util/Triangulate";
+import { V, V2d } from "../core/Vector";
+import {
+  BoatConfig,
+  HullConfig,
+  KeelConfig,
+  RigConfig,
+  RudderConfig,
+} from "../game/boat/BoatConfig";
+import type { BoatEditorCameraController } from "./BoatEditorCameraController";
+
+interface HullMesh {
+  xyPositions: [number, number][];
+  zValues: number[];
+  ringSize: number;
+  deckIndices: number[];
+  upperSideIndices: number[];
+  lowerSideIndices: number[];
+}
+
+export class BoatPreviewRenderer extends BaseEntity {
+  private config: BoatConfig;
+  private camera: BoatEditorCameraController;
+  private mesh: HullMesh | null = null;
+
+  constructor(config: BoatConfig, camera: BoatEditorCameraController) {
+    super();
+    this.config = config;
+    this.camera = camera;
+    this.rebuildMesh();
+  }
+
+  setConfig(config: BoatConfig): void {
+    this.config = config;
+    this.rebuildMesh();
+  }
+
+  private rebuildMesh(): void {
+    const hull = this.config.hull;
+    const deckVertices = hull.vertices;
+    const waterlineVertices = hull.waterlineVertices ?? hull.vertices;
+    const bottomVertices =
+      hull.bottomVertices ?? waterlineVertices.map((v) => V(v.x, v.y * 0.45));
+    const deckZ = hull.deckHeight;
+    const bottomZ = -hull.draft;
+
+    const ringSize = deckVertices.length;
+    const totalVerts = ringSize * 3;
+    const xyPositions: [number, number][] = new Array(totalVerts);
+    const zValues: number[] = new Array(totalVerts);
+
+    for (let i = 0; i < ringSize; i++) {
+      xyPositions[i] = [deckVertices[i].x, deckVertices[i].y];
+      zValues[i] = deckZ;
+    }
+    for (let i = 0; i < ringSize; i++) {
+      xyPositions[ringSize + i] = [
+        waterlineVertices[i].x,
+        waterlineVertices[i].y,
+      ];
+      zValues[ringSize + i] = 0;
+    }
+    for (let i = 0; i < ringSize; i++) {
+      xyPositions[2 * ringSize + i] = [
+        bottomVertices[i].x,
+        bottomVertices[i].y,
+      ];
+      zValues[2 * ringSize + i] = bottomZ;
+    }
+
+    const deckIndices = earClipTriangulate(deckVertices) ?? [];
+    const upperSideIndices: number[] = [];
+    const lowerSideIndices: number[] = [];
+    for (let i = 0; i < ringSize; i++) {
+      const next = (i + 1) % ringSize;
+      const d0 = i,
+        d1 = next;
+      const w0 = ringSize + i,
+        w1 = ringSize + next;
+      const b0 = 2 * ringSize + i,
+        b1 = 2 * ringSize + next;
+      upperSideIndices.push(d0, d1, w1, d0, w1, w0);
+      lowerSideIndices.push(w0, w1, b1, w0, b1, b0);
+    }
+
+    this.mesh = {
+      xyPositions,
+      zValues,
+      ringSize,
+      deckIndices,
+      upperSideIndices,
+      lowerSideIndices,
+    };
+  }
+
+  @on("render")
+  onRender({ draw }: { draw: Draw }) {
+    const { config, camera, mesh } = this;
+    if (!mesh) return;
+
+    // Map orbit camera angles to tilt transform
+    // yaw = rotation around boat, pitch = elevation
+    const angle = -camera.yaw;
+    const roll = 0;
+    const pitch = camera.pitch;
+
+    draw.at(
+      {
+        pos: V(0, 0),
+        angle,
+        tilt: { roll, pitch, zOffset: 0 },
+      },
+      () => {
+        this.renderWaterPlane(draw);
+        this.renderHull(draw, config.hull, mesh);
+        this.renderKeel(draw, config);
+        this.renderRudder(draw, config.rudder, config.tilt.zHeights.rudder);
+        this.renderRig(draw, config.rig, config.hull.deckHeight);
+        if (config.bowsprit) {
+          this.renderBowsprit(
+            draw,
+            config.bowsprit,
+            config.tilt.zHeights.bowsprit,
+          );
+        }
+        if (config.lifelines) {
+          this.renderLifelines(draw, config.lifelines, config.hull.deckHeight);
+        }
+      },
+    );
+  }
+
+  private renderWaterPlane(draw: Draw): void {
+    // Flat blue water plane for reference
+    const size = 50;
+    draw.fillRect(-size, -size, size * 2, size * 2, {
+      color: 0x2244667,
+      alpha: 0.3,
+      z: 0,
+    });
+  }
+
+  private renderHull(draw: Draw, hull: HullConfig, mesh: HullMesh): void {
+    const {
+      xyPositions,
+      zValues,
+      deckIndices,
+      upperSideIndices,
+      lowerSideIndices,
+      ringSize,
+    } = mesh;
+
+    const bottomColor = hull.colors.bottom ?? darken(hull.colors.fill, 0.65);
+    const sideColor = hull.colors.side ?? darken(hull.colors.fill, 0.85);
+
+    // Back-to-front: lower sides → upper sides → deck
+    draw.renderer.submitTrianglesWithZ(
+      xyPositions,
+      lowerSideIndices,
+      bottomColor,
+      1.0,
+      zValues,
+    );
+    draw.renderer.submitTrianglesWithZ(
+      xyPositions,
+      upperSideIndices,
+      sideColor,
+      1.0,
+      zValues,
+    );
+    draw.renderer.submitTrianglesWithZ(
+      xyPositions,
+      deckIndices,
+      hull.colors.fill,
+      1.0,
+      zValues,
+    );
+
+    // Gunwale outline
+    const deckZ = hull.deckHeight;
+    draw.strokePolygon(
+      xyPositions.slice(0, ringSize).map((p) => V(p[0], p[1])),
+      { color: hull.colors.stroke, width: 0.25, z: deckZ },
+    );
+  }
+
+  private renderKeel(draw: Draw, config: BoatConfig): void {
+    const keel = config.keel;
+    const keelZ = config.tilt.zHeights.keel;
+    const verts = keel.vertices;
+    for (let i = 0; i < verts.length - 1; i++) {
+      draw.line(verts[i].x, verts[i].y, verts[i + 1].x, verts[i + 1].y, {
+        color: keel.color,
+        width: 1,
+        z: keelZ,
+      });
+    }
+  }
+
+  private renderRudder(
+    draw: Draw,
+    rudder: RudderConfig,
+    rudderZ: number,
+  ): void {
+    // Rudder at its position, pointing aft (no steering angle in preview)
+    draw.at({ pos: V(rudder.position.x, rudder.position.y) }, () => {
+      draw.line(0, 0, -rudder.length, 0, {
+        color: rudder.color,
+        width: 0.5,
+        z: rudderZ,
+      });
+    });
+  }
+
+  private renderRig(draw: Draw, rig: RigConfig, deckHeight: number): void {
+    const mx = rig.mastPosition.x;
+    const my = rig.mastPosition.y;
+    const stayZ = rig.stays.deckHeight;
+
+    // Standing rigging (forestay, shrouds, backstay)
+    const stays = [
+      rig.stays.forestay,
+      rig.stays.portShroud,
+      rig.stays.starboardShroud,
+      rig.stays.backstay,
+    ];
+    for (const stay of stays) {
+      draw.line(mx, my, stay.x, stay.y, {
+        color: 0x999999,
+        width: 0.1,
+        z: stayZ,
+      });
+    }
+
+    // Boom (resting along centerline)
+    const boomZ = rig.mainsail.zFoot ?? 3;
+    draw.fillRect(mx, -rig.boomWidth / 2, rig.boomLength, rig.boomWidth, {
+      color: rig.colors.boom,
+      z: boomZ,
+    });
+
+    // Mast
+    const mastTopZ = 20; // approximate
+    draw.line(mx, my, mx, my, {
+      color: rig.colors.mast,
+      width: 0.4,
+      z: mastTopZ,
+    });
+    draw.fillCircle(mx, my, 0.3, {
+      color: rig.colors.mast,
+      z: deckHeight,
+    });
+  }
+
+  private renderBowsprit(
+    draw: Draw,
+    bowsprit: NonNullable<BoatConfig["bowsprit"]>,
+    bowspritZ: number,
+  ): void {
+    draw.fillRect(
+      bowsprit.attachPoint.x,
+      bowsprit.attachPoint.y - bowsprit.size.y / 2,
+      bowsprit.size.x,
+      bowsprit.size.y,
+      { color: bowsprit.color, z: bowspritZ },
+    );
+  }
+
+  private renderLifelines(
+    draw: Draw,
+    lifelines: NonNullable<BoatConfig["lifelines"]>,
+    deckHeight: number,
+  ): void {
+    const topZ = deckHeight + lifelines.stanchionHeight;
+
+    // Stanchions
+    for (const s of lifelines.portStanchions) {
+      draw.line(s[0], s[1], s[0], s[1], {
+        color: lifelines.tubeColor,
+        width: lifelines.tubeWidth,
+        z: topZ,
+      });
+    }
+    for (const s of lifelines.starboardStanchions) {
+      draw.line(s[0], s[1], s[0], s[1], {
+        color: lifelines.tubeColor,
+        width: lifelines.tubeWidth,
+        z: topZ,
+      });
+    }
+
+    // Bow pulpit
+    if (lifelines.bowPulpit.length > 1) {
+      draw.renderer.setZ(topZ);
+      const path = draw.path();
+      path.moveTo(lifelines.bowPulpit[0][0], lifelines.bowPulpit[0][1]);
+      for (let i = 1; i < lifelines.bowPulpit.length; i++) {
+        path.lineTo(lifelines.bowPulpit[i][0], lifelines.bowPulpit[i][1]);
+      }
+      path.stroke(lifelines.tubeColor, lifelines.tubeWidth);
+      draw.renderer.setZ(0);
+    }
+
+    // Stern pulpit
+    if (lifelines.sternPulpit.length > 1) {
+      draw.renderer.setZ(topZ);
+      const path = draw.path();
+      path.moveTo(lifelines.sternPulpit[0][0], lifelines.sternPulpit[0][1]);
+      for (let i = 1; i < lifelines.sternPulpit.length; i++) {
+        path.lineTo(lifelines.sternPulpit[i][0], lifelines.sternPulpit[i][1]);
+      }
+      path.stroke(lifelines.tubeColor, lifelines.tubeWidth);
+      draw.renderer.setZ(0);
+    }
+  }
+}
+
+function darken(color: number, factor: number): number {
+  const r = Math.floor(((color >> 16) & 0xff) * factor);
+  const g = Math.floor(((color >> 8) & 0xff) * factor);
+  const b = Math.floor((color & 0xff) * factor);
+  return (r << 16) | (g << 8) | b;
+}

--- a/src/boat-editor/ui/BoatEditorStyles.css
+++ b/src/boat-editor/ui/BoatEditorStyles.css
@@ -1,0 +1,150 @@
+/* Boat Editor Property Panels */
+
+.boat-panels {
+  position: fixed;
+  top: 56px;
+  right: 8px;
+  width: 320px;
+  max-height: calc(100vh - 64px);
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  z-index: 99;
+  font-family: var(--font-body);
+  font-weight: 300;
+  font-size: 13px;
+  color: #e0e0e0;
+}
+
+.boat-panel-section {
+  background: rgba(26, 26, 46, 0.95);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 6px;
+  backdrop-filter: blur(4px);
+  overflow: hidden;
+}
+
+.boat-panel-header {
+  padding: 8px 12px;
+  font-weight: 600;
+  font-size: 13px;
+  cursor: pointer;
+  user-select: none;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.boat-panel-header:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.boat-panel-chevron {
+  font-size: 11px;
+  width: 12px;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.boat-panel-body {
+  padding: 4px 12px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+/* Number field row */
+
+.boat-field {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.boat-field-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.55);
+  letter-spacing: 0.4px;
+  cursor: ew-resize;
+  user-select: none;
+}
+
+.boat-field-controls {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.boat-field-slider {
+  flex: 1;
+  height: 4px;
+  border-radius: 2px;
+  background: rgba(255, 255, 255, 0.1);
+  cursor: pointer;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.boat-field-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #44aa44;
+  cursor: pointer;
+  border: 2px solid #fff;
+}
+
+.boat-field-input {
+  width: 64px;
+  padding: 3px 5px;
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  color: #e0e0e0;
+  border-radius: 3px;
+  font-size: 12px;
+  text-align: right;
+  font-family: var(--font-body);
+}
+
+.boat-field-input:focus {
+  outline: none;
+  border-color: rgba(68, 170, 68, 0.5);
+}
+
+/* Hide number input spinners */
+.boat-field-input::-webkit-inner-spin-button,
+.boat-field-input::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+.boat-field-input[type="number"] {
+  -moz-appearance: textfield;
+}
+
+.boat-field-unit {
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.4);
+  min-width: 20px;
+}
+
+/* Scrollbar styling */
+.boat-panels::-webkit-scrollbar {
+  width: 6px;
+}
+
+.boat-panels::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.boat-panels::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.15);
+  border-radius: 3px;
+}
+
+.boat-panels::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.25);
+}

--- a/src/boat-editor/ui/BoatEditorToolbar.tsx
+++ b/src/boat-editor/ui/BoatEditorToolbar.tsx
@@ -1,0 +1,76 @@
+/**
+ * Top toolbar for the boat editor.
+ * File operations, presets, undo/redo, and view presets.
+ */
+
+import type { BoatEditorController } from "../BoatEditorController";
+import { BOAT_PRESETS } from "../BoatEditorController";
+import "../../editor/ui/EditorStyles.css";
+
+export interface BoatEditorToolbarProps {
+  controller: BoatEditorController;
+}
+
+export function BoatEditorToolbar({ controller }: BoatEditorToolbarProps) {
+  const doc = controller.document;
+  const isDirty = doc.isDirty;
+  const canUndo = doc.canUndo;
+  const canRedo = doc.canRedo;
+
+  return (
+    <div class="editor-toolbar">
+      <span class="editor-toolbar-title">Boat Editor</span>
+      {isDirty && <span class="editor-toolbar-dirty">*</span>}
+
+      <div class="editor-toolbar-group">
+        <select
+          class="editor-btn"
+          onChange={(e) => {
+            const name = (e.target as HTMLSelectElement).value;
+            if (name) controller.loadPreset(name);
+          }}
+        >
+          <option value="">Load Preset...</option>
+          {Object.keys(BOAT_PRESETS).map((name) => (
+            <option key={name} value={name}>
+              {name}
+            </option>
+          ))}
+        </select>
+        <button
+          class="editor-btn"
+          onClick={() => controller.importJSON()}
+          title="Import JSON (Ctrl+O)"
+        >
+          Import
+        </button>
+        <button
+          class="editor-btn editor-btn-primary"
+          onClick={() => controller.exportJSON()}
+          title="Export JSON (Ctrl+S)"
+        >
+          Export
+        </button>
+      </div>
+
+      <div class="editor-toolbar-group">
+        <button
+          class="editor-btn"
+          onClick={() => doc.undo()}
+          disabled={!canUndo}
+          title="Undo (Ctrl+Z)"
+        >
+          Undo
+        </button>
+        <button
+          class="editor-btn"
+          onClick={() => doc.redo()}
+          disabled={!canRedo}
+          title="Redo (Ctrl+Shift+Z)"
+        >
+          Redo
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/boat-editor/ui/BoatPropertyPanels.tsx
+++ b/src/boat-editor/ui/BoatPropertyPanels.tsx
@@ -1,0 +1,645 @@
+/**
+ * Property panels for the boat editor.
+ * Collapsible sections for each part of the BoatConfig.
+ */
+
+import { useState, useCallback, useRef } from "preact/hooks";
+import type { BoatEditorController } from "../BoatEditorController";
+import { SetPropertyCommand } from "../BoatEditorDocument";
+import "../../editor/ui/EditorStyles.css";
+import "./BoatEditorStyles.css";
+
+export interface BoatPropertyPanelsProps {
+  controller: BoatEditorController;
+}
+
+export function BoatPropertyPanels({ controller }: BoatPropertyPanelsProps) {
+  const config = controller.document.config;
+
+  return (
+    <div class="boat-panels">
+      <PanelSection title="Hull" defaultOpen>
+        <NumberField
+          label="Mass"
+          value={config.hull.mass}
+          path="hull.mass"
+          controller={controller}
+          min={50}
+          max={5000}
+          step={10}
+          unit="lbs"
+        />
+        <NumberField
+          label="Draft"
+          value={config.hull.draft}
+          path="hull.draft"
+          controller={controller}
+          min={0}
+          max={10}
+          step={0.1}
+          unit="ft"
+        />
+        <NumberField
+          label="Deck Height"
+          value={config.hull.deckHeight}
+          path="hull.deckHeight"
+          controller={controller}
+          min={0}
+          max={10}
+          step={0.1}
+          unit="ft"
+        />
+        <NumberField
+          label="Skin Friction"
+          value={config.hull.skinFrictionCoefficient}
+          path="hull.skinFrictionCoefficient"
+          controller={controller}
+          min={0.001}
+          max={0.01}
+          step={0.0005}
+        />
+      </PanelSection>
+
+      <PanelSection title="Keel">
+        <NumberField
+          label="Draft"
+          value={config.keel.draft}
+          path="keel.draft"
+          controller={controller}
+          min={0}
+          max={15}
+          step={0.1}
+          unit="ft"
+        />
+        <NumberField
+          label="Chord"
+          value={config.keel.chord}
+          path="keel.chord"
+          controller={controller}
+          min={0.1}
+          max={5}
+          step={0.05}
+          unit="ft"
+        />
+      </PanelSection>
+
+      <PanelSection title="Rudder">
+        <NumberField
+          label="Length"
+          value={config.rudder.length}
+          path="rudder.length"
+          controller={controller}
+          min={0.5}
+          max={10}
+          step={0.1}
+          unit="ft"
+        />
+        <NumberField
+          label="Draft"
+          value={config.rudder.draft}
+          path="rudder.draft"
+          controller={controller}
+          min={0}
+          max={10}
+          step={0.1}
+          unit="ft"
+        />
+        <NumberField
+          label="Chord"
+          value={config.rudder.chord}
+          path="rudder.chord"
+          controller={controller}
+          min={0.1}
+          max={5}
+          step={0.05}
+          unit="ft"
+        />
+        <NumberField
+          label="Max Steer Angle"
+          value={toDeg(config.rudder.maxSteerAngle)}
+          path="rudder.maxSteerAngle"
+          controller={controller}
+          min={5}
+          max={60}
+          step={1}
+          unit="deg"
+          toConfig={toRad}
+          fromConfig={toDeg}
+        />
+      </PanelSection>
+
+      <PanelSection title="Rig">
+        <NumberField
+          label="Boom Length"
+          value={config.rig.boomLength}
+          path="rig.boomLength"
+          controller={controller}
+          min={0.5}
+          max={20}
+          step={0.1}
+          unit="ft"
+        />
+        <NumberField
+          label="Boom Width"
+          value={config.rig.boomWidth}
+          path="rig.boomWidth"
+          controller={controller}
+          min={0.1}
+          max={2}
+          step={0.05}
+          unit="ft"
+        />
+        <NumberField
+          label="Boom Mass"
+          value={config.rig.boomMass}
+          path="rig.boomMass"
+          controller={controller}
+          min={1}
+          max={100}
+          step={1}
+          unit="lbs"
+        />
+      </PanelSection>
+
+      <PanelSection title="Mainsail">
+        <NumberField
+          label="Lift Scale"
+          value={config.rig.mainsail.liftScale ?? 1}
+          path="rig.mainsail.liftScale"
+          controller={controller}
+          min={0}
+          max={3}
+          step={0.05}
+        />
+        <NumberField
+          label="Drag Scale"
+          value={config.rig.mainsail.dragScale ?? 1}
+          path="rig.mainsail.dragScale"
+          controller={controller}
+          min={0}
+          max={3}
+          step={0.05}
+        />
+        <NumberField
+          label="Node Mass"
+          value={config.rig.mainsail.nodeMass ?? 0.5}
+          path="rig.mainsail.nodeMass"
+          controller={controller}
+          min={0.01}
+          max={5}
+          step={0.05}
+        />
+        <NumberField
+          label="Hoist Speed"
+          value={config.rig.mainsail.hoistSpeed ?? 0.3}
+          path="rig.mainsail.hoistSpeed"
+          controller={controller}
+          min={0.05}
+          max={2}
+          step={0.05}
+        />
+      </PanelSection>
+
+      {config.jib && (
+        <PanelSection title="Jib">
+          <NumberField
+            label="Lift Scale"
+            value={config.jib.liftScale ?? 1}
+            path="jib.liftScale"
+            controller={controller}
+            min={0}
+            max={3}
+            step={0.05}
+          />
+          <NumberField
+            label="Drag Scale"
+            value={config.jib.dragScale ?? 1}
+            path="jib.dragScale"
+            controller={controller}
+            min={0}
+            max={3}
+            step={0.05}
+          />
+        </PanelSection>
+      )}
+
+      <PanelSection title="Mainsheet">
+        <NumberField
+          label="Boom Attach Ratio"
+          value={config.mainsheet.boomAttachRatio}
+          path="mainsheet.boomAttachRatio"
+          controller={controller}
+          min={0}
+          max={1}
+          step={0.05}
+        />
+        <NumberField
+          label="Trim Speed"
+          value={config.mainsheet.trimSpeed ?? 3}
+          path="mainsheet.trimSpeed"
+          controller={controller}
+          min={0.5}
+          max={20}
+          step={0.5}
+          unit="ft/s"
+        />
+      </PanelSection>
+
+      <PanelSection title="Tilt / Stability">
+        <NumberField
+          label="Roll Inertia"
+          value={config.tilt.rollInertia}
+          path="tilt.rollInertia"
+          controller={controller}
+          min={100}
+          max={50000}
+          step={100}
+        />
+        <NumberField
+          label="Pitch Inertia"
+          value={config.tilt.pitchInertia}
+          path="tilt.pitchInertia"
+          controller={controller}
+          min={100}
+          max={100000}
+          step={100}
+        />
+        <NumberField
+          label="Roll Damping"
+          value={config.tilt.rollDamping}
+          path="tilt.rollDamping"
+          controller={controller}
+          min={100}
+          max={50000}
+          step={100}
+        />
+        <NumberField
+          label="Pitch Damping"
+          value={config.tilt.pitchDamping}
+          path="tilt.pitchDamping"
+          controller={controller}
+          min={100}
+          max={100000}
+          step={100}
+        />
+        <NumberField
+          label="Righting Moment"
+          value={config.tilt.rightingMomentCoeff}
+          path="tilt.rightingMomentCoeff"
+          controller={controller}
+          min={1000}
+          max={200000}
+          step={1000}
+        />
+        <NumberField
+          label="Pitch Righting"
+          value={config.tilt.pitchRightingCoeff}
+          path="tilt.pitchRightingCoeff"
+          controller={controller}
+          min={1000}
+          max={200000}
+          step={1000}
+        />
+        <NumberField
+          label="Max Roll"
+          value={toDeg(config.tilt.maxRoll)}
+          path="tilt.maxRoll"
+          controller={controller}
+          min={5}
+          max={90}
+          step={1}
+          unit="deg"
+          toConfig={toRad}
+          fromConfig={toDeg}
+        />
+        <NumberField
+          label="Max Pitch"
+          value={toDeg(config.tilt.maxPitch)}
+          path="tilt.maxPitch"
+          controller={controller}
+          min={5}
+          max={60}
+          step={1}
+          unit="deg"
+          toConfig={toRad}
+          fromConfig={toDeg}
+        />
+      </PanelSection>
+
+      <PanelSection title="Buoyancy">
+        <NumberField
+          label="Vertical Mass"
+          value={config.buoyancy.verticalMass}
+          path="buoyancy.verticalMass"
+          controller={controller}
+          min={50}
+          max={10000}
+          step={10}
+          unit="lbs"
+        />
+        <NumberField
+          label="CG Height"
+          value={config.buoyancy.centerOfGravityZ}
+          path="buoyancy.centerOfGravityZ"
+          controller={controller}
+          min={-5}
+          max={5}
+          step={0.1}
+          unit="ft"
+        />
+      </PanelSection>
+
+      <PanelSection title="Bilge">
+        <NumberField
+          label="Max Water Volume"
+          value={config.bilge.maxWaterVolume}
+          path="bilge.maxWaterVolume"
+          controller={controller}
+          min={1}
+          max={100}
+          step={1}
+          unit="ft³"
+        />
+        <NumberField
+          label="Bail Bucket Size"
+          value={config.bilge.bailBucketSize}
+          path="bilge.bailBucketSize"
+          controller={controller}
+          min={0.05}
+          max={2}
+          step={0.05}
+          unit="ft³"
+        />
+        <NumberField
+          label="Slosh Gravity"
+          value={config.bilge.sloshGravity}
+          path="bilge.sloshGravity"
+          controller={controller}
+          min={0}
+          max={20}
+          step={0.5}
+        />
+      </PanelSection>
+
+      <PanelSection title="Grounding">
+        <NumberField
+          label="Keel Friction"
+          value={config.grounding.keelFriction}
+          path="grounding.keelFriction"
+          controller={controller}
+          min={0}
+          max={5000}
+          step={50}
+        />
+        <NumberField
+          label="Rudder Friction"
+          value={config.grounding.rudderFriction}
+          path="grounding.rudderFriction"
+          controller={controller}
+          min={0}
+          max={5000}
+          step={50}
+        />
+        <NumberField
+          label="Hull Friction"
+          value={config.grounding.hullFriction}
+          path="grounding.hullFriction"
+          controller={controller}
+          min={0}
+          max={10000}
+          step={100}
+        />
+      </PanelSection>
+
+      <PanelSection title="Damage">
+        <NumberField
+          label="Sail Overpower Threshold"
+          value={config.sailDamage.overpowerForceThreshold}
+          path="sailDamage.overpowerForceThreshold"
+          controller={controller}
+          min={50}
+          max={2000}
+          step={10}
+          unit="lbf"
+        />
+        <NumberField
+          label="Max Lift Reduction"
+          value={config.sailDamage.maxLiftReduction}
+          path="sailDamage.maxLiftReduction"
+          controller={controller}
+          min={0}
+          max={1}
+          step={0.05}
+        />
+        <NumberField
+          label="Max Steering Reduction"
+          value={config.rudderDamage.maxSteeringReduction}
+          path="rudderDamage.maxSteeringReduction"
+          controller={controller}
+          min={0}
+          max={1}
+          step={0.05}
+        />
+      </PanelSection>
+
+      <PanelSection title="Anchor">
+        <NumberField
+          label="Max Rode Length"
+          value={config.anchor.maxRodeLength}
+          path="anchor.maxRodeLength"
+          controller={controller}
+          min={10}
+          max={200}
+          step={5}
+          unit="ft"
+        />
+        <NumberField
+          label="Anchor Mass"
+          value={config.anchor.anchorMass}
+          path="anchor.anchorMass"
+          controller={controller}
+          min={1}
+          max={200}
+          step={1}
+          unit="lbs"
+        />
+        <NumberField
+          label="Drag Coefficient"
+          value={config.anchor.anchorDragCoefficient}
+          path="anchor.anchorDragCoefficient"
+          controller={controller}
+          min={10}
+          max={1000}
+          step={10}
+        />
+      </PanelSection>
+
+      <PanelSection title="Rowing">
+        <NumberField
+          label="Stroke Duration"
+          value={config.rowing.duration}
+          path="rowing.duration"
+          controller={controller}
+          min={0.1}
+          max={3}
+          step={0.05}
+          unit="s"
+        />
+        <NumberField
+          label="Stroke Force"
+          value={config.rowing.force}
+          path="rowing.force"
+          controller={controller}
+          min={100}
+          max={20000}
+          step={100}
+          unit="lbf"
+        />
+      </PanelSection>
+    </div>
+  );
+}
+
+// ============================================
+// Reusable components
+// ============================================
+
+function PanelSection({
+  title,
+  defaultOpen = false,
+  children,
+}: {
+  title: string;
+  defaultOpen?: boolean;
+  children: preact.ComponentChildren;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div class={`boat-panel-section ${open ? "open" : ""}`}>
+      <div class="boat-panel-header" onClick={() => setOpen(!open)}>
+        <span class="boat-panel-chevron">{open ? "\u25BE" : "\u25B8"}</span>
+        {title}
+      </div>
+      {open && <div class="boat-panel-body">{children}</div>}
+    </div>
+  );
+}
+
+interface NumberFieldProps {
+  label: string;
+  value: number;
+  path: string;
+  controller: BoatEditorController;
+  min: number;
+  max: number;
+  step: number;
+  unit?: string;
+  toConfig?: (displayValue: number) => number;
+  fromConfig?: (configValue: number) => number;
+}
+
+function NumberField({
+  label,
+  value,
+  path,
+  controller,
+  min,
+  max,
+  step,
+  unit,
+  toConfig,
+  fromConfig,
+}: NumberFieldProps) {
+  const displayValue = fromConfig ? fromConfig(value) : value;
+  const dragRef = useRef<{
+    startX: number;
+    startValue: number;
+    committed: boolean;
+  } | null>(null);
+
+  const commitValue = useCallback(
+    (displayVal: number) => {
+      const clamped = Math.max(min, Math.min(max, displayVal));
+      const configVal = toConfig ? toConfig(clamped) : clamped;
+      controller.document.executeCommand(
+        new SetPropertyCommand(controller.document, path, configVal),
+      );
+    },
+    [controller, path, min, max, toConfig],
+  );
+
+  return (
+    <div class="boat-field">
+      <label
+        class="boat-field-label"
+        onMouseDown={(e: MouseEvent) => {
+          e.preventDefault();
+          dragRef.current = {
+            startX: e.clientX,
+            startValue: displayValue,
+            committed: false,
+          };
+          const onMove = (me: MouseEvent) => {
+            if (!dragRef.current) return;
+            const dx = me.clientX - dragRef.current.startX;
+            const newVal =
+              dragRef.current.startValue + dx * step * (me.shiftKey ? 0.1 : 1);
+            commitValue(newVal);
+            dragRef.current.committed = true;
+          };
+          const onUp = () => {
+            dragRef.current = null;
+            window.removeEventListener("mousemove", onMove);
+            window.removeEventListener("mouseup", onUp);
+          };
+          window.addEventListener("mousemove", onMove);
+          window.addEventListener("mouseup", onUp);
+        }}
+      >
+        {label}
+      </label>
+      <div class="boat-field-controls">
+        <input
+          type="range"
+          class="boat-field-slider"
+          min={min}
+          max={max}
+          step={step}
+          value={displayValue}
+          onInput={(e) => {
+            commitValue(parseFloat((e.target as HTMLInputElement).value));
+          }}
+        />
+        <input
+          type="number"
+          class="boat-field-input"
+          min={min}
+          max={max}
+          step={step}
+          value={roundDisplay(displayValue, step)}
+          onChange={(e) => {
+            commitValue(parseFloat((e.target as HTMLInputElement).value));
+          }}
+        />
+        {unit && <span class="boat-field-unit">{unit}</span>}
+      </div>
+    </div>
+  );
+}
+
+// ============================================
+// Helpers
+// ============================================
+
+function toDeg(rad: number): number {
+  return (rad * 180) / Math.PI;
+}
+
+function toRad(deg: number): number {
+  return (deg * Math.PI) / 180;
+}
+
+function roundDisplay(value: number, step: number): number {
+  const decimals = Math.max(0, -Math.floor(Math.log10(step)));
+  return parseFloat(value.toFixed(decimals));
+}

--- a/tests/boat-editor.spec.ts
+++ b/tests/boat-editor.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "@playwright/test";
+
+test("boat editor initializes and runs without errors", async ({ page }) => {
+  const issues: string[] = [];
+  page.on("pageerror", (err) => issues.push(err.message));
+  page.on("console", (msg) => {
+    if (msg.type() === "error" || msg.type() === "warning")
+      issues.push(msg.text());
+  });
+
+  await page.goto("/boat-editor.html");
+
+  // Wait for the editor's game loop to initialize
+  await page.waitForFunction(() => window.BOAT_EDITOR_DEBUG?.game, {
+    timeout: 30000,
+  });
+
+  // --- Assertion: Game loop is running ---
+  const tickCount = await page.evaluate(
+    () => window.BOAT_EDITOR_DEBUG.game!.ticknumber,
+  );
+  expect(tickCount).toBeGreaterThan(0);
+
+  // Let it run briefly to catch any post-init errors
+  await page.waitForTimeout(2000);
+
+  // --- Assertion: No errors during startup ---
+  expect(issues).toHaveLength(0);
+});

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -35,7 +35,7 @@ test("game initializes, shows main menu, and starts without errors", async ({
   const mainMenu = page.locator(".main-menu");
   await expect(mainMenu).toBeVisible({ timeout: 30000 });
   await expect(mainMenu).toContainText("Tack & Trim");
-  await expect(mainMenu).toContainText("Select a Level");
+  await expect(mainMenu).toContainText("New Game");
 
   // --- Assertion: No errors during initialization ---
   expect(issues).toHaveLength(0);

--- a/tests/editor.spec.ts
+++ b/tests/editor.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from "@playwright/test";
+
+test("terrain editor initializes and runs without errors", async ({ page }) => {
+  const issues: string[] = [];
+  page.on("pageerror", (err) => issues.push(err.message));
+  page.on("console", (msg) => {
+    if (msg.type() === "error" || msg.type() === "warning") {
+      // Wave physics warning is expected in the editor (no prebuilt mesh data)
+      if (msg.text().includes("wave physics will be inactive")) return;
+      issues.push(msg.text());
+    }
+  });
+
+  await page.goto("/editor.html");
+
+  // Wait for the editor's game loop to initialize
+  await page.waitForFunction(() => window.EDITOR_DEBUG?.game, {
+    timeout: 30000,
+  });
+
+  // --- Assertion: Game loop is running ---
+  const tickCount = await page.evaluate(
+    () => window.EDITOR_DEBUG.game!.ticknumber,
+  );
+  expect(tickCount).toBeGreaterThan(0);
+
+  // Let it run briefly to catch any post-init errors
+  await page.waitForTimeout(2000);
+
+  // --- Assertion: No errors during startup ---
+  expect(issues).toHaveLength(0);
+});

--- a/tests/global.d.ts
+++ b/tests/global.d.ts
@@ -1,6 +1,8 @@
 declare global {
   interface Window {
     DEBUG: { game: { ticknumber: number; framenumber: number } };
+    EDITOR_DEBUG: { game?: { ticknumber: number; framenumber: number } };
+    BOAT_EDITOR_DEBUG: { game?: { ticknumber: number; framenumber: number } };
   }
 }
 export {};


### PR DESCRIPTION
## Summary
- Standalone boat editor at `/boat-editor.html` for authoring and tuning `BoatConfig` objects
- Orbit camera (drag to rotate, scroll to zoom, space+drag to pan) using the existing tilt projection system
- Live 3D preview rendering hull mesh, keel, rudder, rig, bowsprit, and lifelines from config
- Collapsible property panels with sliders/inputs for all config sections (hull, keel, rudder, rig, sails, tilt/stability, buoyancy, bilge, grounding, damage, anchor, rowing)
- Undo/redo, preset loading (StarterDinghy/StarterBoat), JSON import/export
- E2E smoke tests for both the terrain editor and boat editor
- Fix existing e2e test (menu text changed to "New Game")

## Test plan
- [x] `npx tsgo --noEmit` passes
- [x] `npx playwright test` — all 3 tests pass
- [ ] Open `/boat-editor.html` in dev server, verify boat renders and panels work
- [ ] Drag to orbit, scroll to zoom, adjust sliders, verify live preview updates
- [ ] Test undo/redo (Ctrl+Z/Y), export JSON, import JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)