### PR TITLE
Add tidal current flow field system using FEM on CDT mesh

### DIFF
--- a/bin/build-level
+++ b/bin/build-level
@@ -36,6 +36,7 @@ Usage:
   build-level build [--level <name>]              Run full pipeline + mesh build (all if omitted)
   build-level wave-mesh [--level <name>]          Build wave mesh(es) (all if omitted)
   build-level wind-mesh [--level <name>]          Build wind mesh(es) (all if omitted)
+  build-level tide-mesh [--level <name>]          Build tide mesh(es) (all if omitted)
   build-level trees [--level <name>]              Generate tree positions (all if omitted)
   build-level extract [--level <name>]            Extract terrain (all regions if omitted)
   build-level download [--level <name>]           Download elevation tiles (all regions if omitted)
@@ -76,6 +77,7 @@ _build_level() {
       'build[Run full pipeline]' \
       'wave-mesh[Build .wavemesh files only]' \
       'wind-mesh[Build .windmesh files only]' \
+      'tide-mesh[Build .tidemesh files only]' \
       'download[Download terrain tiles]' \
       'build-grid[Build merged terrain grid cache]' \
       'extract[Extract terrain contours]' \
@@ -101,7 +103,7 @@ _build_level() {
         '-h[Show help]' \
         '--help[Show help]'
       ;;
-    wave-mesh|wind-mesh|trees)
+    wave-mesh|wind-mesh|tide-mesh|trees)
       _arguments \
         '--level[Level name]:level:_build_level_levels' \
         '-h[Show help]' \
@@ -170,7 +172,7 @@ case "${1:-}" in
     echo "Usage: build-level completion zsh" >&2
     exit 2
     ;;
-  build|wave-mesh|wind-mesh|trees|download|build-grid|extract|clean|validate|import )
+  build|wave-mesh|wind-mesh|tide-mesh|trees|download|build-grid|extract|clean|validate|import )
     run_rust_cli "$@"
     ;;
   --* )

--- a/bin/generate-asset-types.ts
+++ b/bin/generate-asset-types.ts
@@ -25,6 +25,7 @@ const manifestFileTemplate = (
   jsonFiles: string[],
   wavemeshFiles: string[],
   windmeshFiles: string[],
+  tidemeshFiles: string[],
   treesFiles: string[],
   varName: (file: string) => string,
 ) =>
@@ -96,6 +97,13 @@ ${windmeshFiles
 };
 export type WindmeshName = keyof typeof windmeshes;
 
+const tidemeshes = {
+${tidemeshFiles
+  .map((tm) => /*ts*/ `  ${varName(tm)}: "/assets/${tm.replace(/^\.\//, "")}"`)
+  .join(",\n")}
+};
+export type TidemeshName = keyof typeof tidemeshes;
+
 const trees = {
 ${treesFiles
   .map((t) => /*ts*/ `  ${varName(t)}: "/assets/${t.replace(/^\.\//, "")}"`)
@@ -103,7 +111,7 @@ ${treesFiles
 };
 export type TreesName = keyof typeof trees;
 
-export const RESOURCES = { sounds, images, fonts, levels, terrains, entityDefs, jsonBlobs, wavemeshes, windmeshes, trees };
+export const RESOURCES = { sounds, images, fonts, levels, terrains, entityDefs, jsonBlobs, wavemeshes, windmeshes, tidemeshes, trees };
 `.trimStart();
 
 /*
@@ -142,13 +150,14 @@ async function main() {
     terrain: "terrain",
     wavemesh: "wavemesh",
     windmesh: "windmesh",
+    tidemesh: "tidemesh",
     trees: "trees",
   } as const;
   type FileExtension = keyof typeof extensionToType;
   type ResourceType = (typeof extensionToType)[FileExtension] | "res";
 
   /** Extensions served statically (no Parcel processing, no .d.ts needed). */
-  const staticExtensions = new Set(["terrain", "wavemesh", "windmesh", "trees"]);
+  const staticExtensions = new Set(["terrain", "wavemesh", "windmesh", "tidemesh", "trees"]);
 
   const extensions = Object.keys(extensionToType);
   const extensionPattern = extensions.join("|");
@@ -245,6 +254,7 @@ async function main() {
     const jsonFiles: string[] = [];
     const wavemeshFiles: string[] = [];
     const windmeshFiles: string[] = [];
+    const tidemeshFiles: string[] = [];
     const treesFiles: string[] = [];
 
     for (const fileName of fileNames) {
@@ -298,6 +308,9 @@ async function main() {
         case "windmesh":
           windmeshFiles.push(relativePath);
           break;
+        case "tidemesh":
+          tidemeshFiles.push(relativePath);
+          break;
         case "trees":
           treesFiles.push(relativePath);
           break;
@@ -320,6 +333,7 @@ async function main() {
       jsonFiles,
       wavemeshFiles,
       windmeshFiles,
+      tidemeshFiles,
       treesFiles,
       varName,
     );

--- a/pipeline/Cargo.lock
+++ b/pipeline/Cargo.lock
@@ -36,6 +36,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,6 +479,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -547,6 +559,12 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -694,6 +712,17 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "zerocopy",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
 ]
 
 [[package]]
@@ -1093,6 +1122,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "maybe-rayon"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1146,6 +1185,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "nalgebra"
+version = "0.33.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d43ddcacf343185dfd6de2ee786d9e8b1c2301622afab66b6c73baf9882abfd"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "nalgebra-macros",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "simba",
+ "typenum",
+]
+
+[[package]]
+name = "nalgebra-macros"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "254a5372af8fc138e36684761d3c0cdb758a4410e938babcff1c860ce14ddbfc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "nalgebra-sparse"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1107e2587bc373090389bd5b54e05ac3184fd02d7c102decf5d76b8feb84b2d0"
+dependencies = [
+ "nalgebra",
+ "num-traits",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1183,6 +1259,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -1525,6 +1610,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
 name = "rayon"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1634,6 +1725,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "robust"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1698,6 +1795,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "semver"
@@ -1767,6 +1873,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simba"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c99284beb21666094ba2b75bbceda012e610f5479dfcc2d6e2426f53197ffd95"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1801,6 +1920,18 @@ checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "spade"
+version = "2.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9699399fd9349b00b184f5635b074f9ec93afffef30c853f8c875b32c0f8c7fa"
+dependencies = [
+ "hashbrown",
+ "num-traits",
+ "robust",
+ "smallvec",
 ]
 
 [[package]]
@@ -2031,6 +2162,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2167,10 +2304,13 @@ dependencies = [
  "anyhow",
  "clap",
  "glob",
+ "nalgebra",
+ "nalgebra-sparse",
  "num-format",
  "rayon",
  "serde",
  "serde_json",
+ "spade",
  "tempfile",
  "terrain-core",
 ]
@@ -2209,6 +2349,16 @@ name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
 
 [[package]]
 name = "windows-link"

--- a/pipeline/build-level/src/main.rs
+++ b/pipeline/build-level/src/main.rs
@@ -49,6 +49,8 @@ enum Commands {
     WaveMesh,
     /// Build wind mesh (.windmesh) for level(s)
     WindMesh,
+    /// Build tide mesh (.tidemesh) for level(s)
+    TideMesh,
     /// Generate tree positions (.trees) for level(s)
     Trees,
     /// Extract terrain → .terrain
@@ -89,6 +91,7 @@ fn main() -> Result<()> {
         Some(Commands::Build) => run_build(level_filter, &view),
         Some(Commands::WaveMesh) => run_wave_mesh(level_filter, &view),
         Some(Commands::WindMesh) => run_wind_mesh(level_filter, &view),
+        Some(Commands::TideMesh) => run_tide_mesh(level_filter, &view),
         Some(Commands::Trees) => run_trees(level_filter, &view),
         Some(Commands::Extract) => {
             let region = resolve_region_for_terrain_command("extract", level_filter)?;
@@ -319,11 +322,52 @@ fn run_trees_for_level(level_path: &Path, slug: &str, view: &StepView) -> Result
     Ok(())
 }
 
+fn run_tide_mesh(level_filter: Option<&str>, view: &StepView) -> Result<()> {
+    let level_paths = resolve_level_paths(level_filter)?;
+    if level_paths.is_empty() {
+        view.info("No level files found.");
+        return Ok(());
+    }
+
+    view.info(format!(
+        "Building tide mesh for {} level(s)",
+        format_int(level_paths.len())
+    ));
+
+    for level_path in &level_paths {
+        view.header(&level_slug_from_path(level_path));
+        run_tide_mesh_for_level(level_path, &level_slug_from_path(level_path), &view.indented())?;
+    }
+
+    view.info("Done.");
+    Ok(())
+}
+
+fn run_tide_mesh_for_level(level_path: &Path, slug: &str, view: &StepView) -> Result<()> {
+    let level_path_str = level_path
+        .to_str()
+        .ok_or_else(|| anyhow!("Invalid level path"))?;
+    let output_path = region::tidemesh_output_path(slug);
+    let output_str = output_path
+        .to_str()
+        .ok_or_else(|| anyhow!("Invalid tidemesh output path"))?;
+    let inner = view.indented();
+    let _s = view.section("build-tidemesh");
+    wavemesh_builder::build_tidemesh_for_level_with_view(
+        level_path_str,
+        Some(output_str),
+        Some(&inner),
+    )?;
+    drop(_s);
+    Ok(())
+}
+
 fn run_all_meshes_for_level(level_path: &Path, slug: &str, view: &StepView) -> Result<()> {
     run_wave_mesh_for_level(level_path, slug, view)?;
     // Generate trees before wind mesh so tree data is available for wind
     run_trees_for_level(level_path, slug, view)?;
     run_wind_mesh_for_level(level_path, slug, view)?;
+    run_tide_mesh_for_level(level_path, slug, view)?;
     Ok(())
 }
 

--- a/pipeline/build-level/src/region.rs
+++ b/pipeline/build-level/src/region.rs
@@ -22,6 +22,11 @@ pub fn windmesh_output_path(slug: &str) -> PathBuf {
     repo_root().join(format!("static/levels/{}.windmesh", slug))
 }
 
+/// Convention-based path for a region's tidemesh output file.
+pub fn tidemesh_output_path(slug: &str) -> PathBuf {
+    repo_root().join(format!("static/levels/{}.tidemesh", slug))
+}
+
 /// Convention-based path for a region's trees output file.
 pub fn trees_output_path(slug: &str) -> PathBuf {
     repo_root().join(format!("static/levels/{}.trees", slug))

--- a/pipeline/wavemesh-builder/Cargo.toml
+++ b/pipeline/wavemesh-builder/Cargo.toml
@@ -12,6 +12,9 @@ anyhow = "1"
 rayon = "1"
 glob = "0.3"
 num-format = "0.4"
+spade = "2"
+nalgebra = "0.33"
+nalgebra-sparse = "0.10"
 
 [dev-dependencies]
 tempfile = "3"

--- a/pipeline/wavemesh-builder/src/lib.rs
+++ b/pipeline/wavemesh-builder/src/lib.rs
@@ -15,6 +15,8 @@ mod wavefront;
 mod wavemesh_file;
 mod windmesh;
 mod windmesh_file;
+pub mod tidemesh;
+mod tidemesh_file;
 
 use std::sync::Arc;
 
@@ -468,6 +470,106 @@ pub fn build_windmesh_for_level_with_view(
                 short_path(&windmesh_path),
                 buffer.len() as f64 / 1024.0,
                 format_int(meshes.len()),
+                format_ms(d)
+            )
+        },
+    )?;
+
+    Ok(())
+}
+
+pub fn build_tidemesh_for_level_with_view(
+    level_path: &str,
+    output: Option<&str>,
+    view: Option<&StepView>,
+) -> anyhow::Result<()> {
+    let owned_view;
+    let view = match view {
+        Some(v) => v,
+        None => {
+            owned_view = StepView::new();
+            &owned_view
+        }
+    };
+
+    let tidemesh_path = output
+        .map(std::string::ToString::to_string)
+        .unwrap_or_else(|| level_path.replace(".level.json", ".tidemesh"));
+
+    let terrain_data = view.try_run_step(
+        "Parsing level for tide mesh",
+        || -> anyhow::Result<_> {
+            let json_str = std::fs::read_to_string(level_path)
+                .with_context(|| format!("failed to read level file: {level_path}"))?;
+            let level_file = level::parse_level_file(&json_str)
+                .with_context(|| format!("failed to parse level JSON: {level_path}"))?;
+
+            // Load terrain: prefer precomputed binary, fall back to building from contours
+            let terrain = if let Some(terrain_path) =
+                level::resolve_terrain_path(&level_file, std::path::Path::new(level_path))?
+            {
+                let bytes = std::fs::read(&terrain_path).with_context(|| {
+                    format!("failed to read terrain file: {}", terrain_path.display())
+                })?;
+                level::read_terrain_binary(&bytes).with_context(|| {
+                    format!("failed to parse terrain file: {}", terrain_path.display())
+                })?
+            } else {
+                let mut lf = level_file;
+                level::resolve_level_terrain(&mut lf, std::path::Path::new(level_path))?;
+                level::build_terrain_data(&lf)
+            };
+
+            Ok(terrain)
+        },
+        |td, d| {
+            format!(
+                "Parsed level: {}ms ({} contours)",
+                format_ms(d),
+                format_int(td.contour_count),
+            )
+        },
+    )?;
+
+    let config = tidemesh::resolve_tidemesh_config();
+    let input_hash =
+        tidemesh_file::compute_tide_input_hash(&terrain_data, &config.tide_levels);
+    view.info(format!(
+        "Input hash: 0x{:08x}{:08x}",
+        input_hash[0], input_hash[1]
+    ));
+    view.info(format!(
+        "Tide levels: {:?}",
+        config.tide_levels
+    ));
+
+    let mesh = view.run_step(
+        "Building tide mesh",
+        || tidemesh::build_tide_mesh(&terrain_data, &config),
+        |mesh, d| {
+            format!(
+                "Built tide mesh: {} verts, {} tris, {} tide levels ({:.1}s)",
+                format_int(mesh.vertex_count),
+                format_int(mesh.triangle_count),
+                format_int(mesh.tide_levels.len()),
+                d.as_secs_f64()
+            )
+        },
+    );
+
+    view.try_run_step(
+        "Writing tidemesh",
+        || -> anyhow::Result<_> {
+            let buffer = tidemesh_file::build_tidemesh_buffer(&mesh, input_hash);
+            std::fs::write(&tidemesh_path, &buffer)
+                .with_context(|| format!("failed to write tidemesh file: {tidemesh_path}"))?;
+            Ok(buffer)
+        },
+        |buffer, d| {
+            format!(
+                "Wrote {} ({:.1} KB) in {}ms",
+                short_path(&tidemesh_path),
+                buffer.len() as f64 / 1024.0,
                 format_ms(d)
             )
         },

--- a/pipeline/wavemesh-builder/src/tidemesh.rs
+++ b/pipeline/wavemesh-builder/src/tidemesh.rs
@@ -1,0 +1,732 @@
+//! Tidal flow mesh builder: CDT mesh generation, FEM solver, velocity recovery.
+//!
+//! Builds an adaptive triangle mesh from terrain contours using Constrained
+//! Delaunay Triangulation, solves for steady-state tidal flow using finite
+//! elements, and produces per-vertex velocity fields for runtime sampling.
+
+use crate::level::TerrainCPUData;
+use crate::terrain::{compute_terrain_height, parse_contours, ContourLookupGrid, ParsedContour};
+
+use nalgebra_sparse::CooMatrix;
+use spade::{ConstrainedDelaunayTriangulation, Point2, Triangulation};
+
+// ── Configuration ───────────────────────────────────────────────────────────
+
+#[derive(Clone, Debug)]
+pub struct TidemeshConfig {
+    pub tide_levels: Vec<f64>,
+    pub min_depth_threshold: f64,
+    pub decimation_velocity_tolerance: f64,
+    pub domain_margin: f64,
+}
+
+pub fn resolve_tidemesh_config() -> TidemeshConfig {
+    let mut config = TidemeshConfig {
+        tide_levels: vec![-2.0, 0.0, 2.0],
+        min_depth_threshold: 0.1,
+        decimation_velocity_tolerance: 0.02,
+        domain_margin: 500.0,
+    };
+
+    if let Ok(val) = std::env::var("TIDEMESH_MIN_DEPTH") {
+        if let Ok(v) = val.parse::<f64>() {
+            config.min_depth_threshold = v;
+        }
+    }
+    if let Ok(val) = std::env::var("TIDEMESH_DECIMATION_TOLERANCE") {
+        if let Ok(v) = val.parse::<f64>() {
+            config.decimation_velocity_tolerance = v;
+        }
+    }
+    if let Ok(val) = std::env::var("TIDEMESH_MARGIN") {
+        if let Ok(v) = val.parse::<f64>() {
+            config.domain_margin = v;
+        }
+    }
+
+    config
+}
+
+// ── Output ──────────────────────────────────────────────────────────────────
+
+pub struct TideMeshData {
+    /// Vertex positions: x, y per vertex (2 f32s each)
+    pub vertex_positions: Vec<f32>,
+    /// Triangle indices: 3 per triangle
+    pub indices: Vec<u32>,
+    pub vertex_count: usize,
+    pub triangle_count: usize,
+    /// Per tide level flow data (flat): for each tide level, vertexCount * 4 f32s
+    /// Layout: [vx_a, vy_a, vx_b, vy_b] per vertex
+    pub flow_data: Vec<f32>,
+    pub tide_levels: Vec<f64>,
+    // Spatial grid
+    pub grid_cols: usize,
+    pub grid_rows: usize,
+    pub grid_min_x: f64,
+    pub grid_min_y: f64,
+    pub grid_cell_width: f64,
+    pub grid_cell_height: f64,
+    pub grid_cell_offsets: Vec<u32>,
+    pub grid_cell_counts: Vec<u32>,
+    pub grid_triangle_lists: Vec<u32>,
+}
+
+// ── Main entry point ────────────────────────────────────────────────────────
+
+pub fn build_tide_mesh(terrain: &TerrainCPUData, config: &TidemeshConfig) -> TideMeshData {
+    let (contours, lookup_grid) = parse_contours(terrain);
+
+    if contours.is_empty() {
+        return empty_tide_mesh(&config.tide_levels);
+    }
+
+    // 1. Extract contour polylines
+    let polylines = extract_contour_polylines(terrain, &contours);
+
+    // 2. Compute domain bounds
+    let (min_x, min_y, max_x, max_y) = compute_domain_bounds(terrain, config.domain_margin);
+
+    // 3. Build CDT mesh
+    let (vertices, triangles, boundary_verts) =
+        build_cdt_mesh(&polylines, min_x, min_y, max_x, max_y);
+
+    if vertices.is_empty() || triangles.is_empty() {
+        return empty_tide_mesh(&config.tide_levels);
+    }
+
+    // 4. For each tide level, solve FEM
+    let mut all_flow_data: Vec<f32> = Vec::new();
+    let vertex_count = vertices.len();
+
+    for &tide_height in &config.tide_levels {
+        let (vel_a, vel_b) = solve_for_tide_level(
+            &vertices,
+            &triangles,
+            &boundary_verts,
+            terrain,
+            &contours,
+            &lookup_grid,
+            tide_height,
+            config.min_depth_threshold,
+        );
+
+        // Pack as vx_a, vy_a, vx_b, vy_b per vertex
+        for i in 0..vertex_count {
+            all_flow_data.push(vel_a[i * 2] as f32);
+            all_flow_data.push(vel_a[i * 2 + 1] as f32);
+            all_flow_data.push(vel_b[i * 2] as f32);
+            all_flow_data.push(vel_b[i * 2 + 1] as f32);
+        }
+    }
+
+    // 5. Build spatial grid
+    let vertex_positions: Vec<f32> = vertices
+        .iter()
+        .flat_map(|v| [v[0] as f32, v[1] as f32])
+        .collect();
+
+    let indices: Vec<u32> = triangles
+        .iter()
+        .flat_map(|t| [t[0] as u32, t[1] as u32, t[2] as u32])
+        .collect();
+
+    let triangle_count = triangles.len();
+    let (grid_cols, grid_rows, grid_min_x, grid_min_y, grid_cell_width, grid_cell_height, grid_cell_offsets, grid_cell_counts, grid_triangle_lists) =
+        build_spatial_grid(&vertices, &triangles, min_x, min_y, max_x, max_y);
+
+    TideMeshData {
+        vertex_positions,
+        indices,
+        vertex_count,
+        triangle_count,
+        flow_data: all_flow_data,
+        tide_levels: config.tide_levels.clone(),
+        grid_cols,
+        grid_rows,
+        grid_min_x,
+        grid_min_y,
+        grid_cell_width,
+        grid_cell_height,
+        grid_cell_offsets,
+        grid_cell_counts,
+        grid_triangle_lists,
+    }
+}
+
+// ── Contour extraction ──────────────────────────────────────────────────────
+
+struct ContourPolyline {
+    points: Vec<[f64; 2]>,
+    #[allow(dead_code)]
+    height: f64,
+}
+
+fn extract_contour_polylines(
+    terrain: &TerrainCPUData,
+    contours: &[ParsedContour],
+) -> Vec<ContourPolyline> {
+    let mut polylines = Vec::new();
+    for c in contours {
+        let mut points = Vec::with_capacity(c.point_count);
+        for i in 0..c.point_count {
+            let idx = (c.point_start + i) * 2;
+            if idx + 1 < terrain.vertex_data.len() {
+                let x = terrain.vertex_data[idx] as f64;
+                let y = terrain.vertex_data[idx + 1] as f64;
+                points.push([x, y]);
+            }
+        }
+        if points.len() >= 3 {
+            polylines.push(ContourPolyline {
+                points,
+                height: c.height as f64,
+            });
+        }
+    }
+    polylines
+}
+
+// ── Domain bounds ───────────────────────────────────────────────────────────
+
+fn compute_domain_bounds(terrain: &TerrainCPUData, margin: f64) -> (f64, f64, f64, f64) {
+    let mut min_x = f64::INFINITY;
+    let mut min_y = f64::INFINITY;
+    let mut max_x = f64::NEG_INFINITY;
+    let mut max_y = f64::NEG_INFINITY;
+
+    let vert_count = terrain.vertex_data.len() / 2;
+    for i in 0..vert_count {
+        let x = terrain.vertex_data[i * 2] as f64;
+        let y = terrain.vertex_data[i * 2 + 1] as f64;
+        min_x = min_x.min(x);
+        min_y = min_y.min(y);
+        max_x = max_x.max(x);
+        max_y = max_y.max(y);
+    }
+
+    (min_x - margin, min_y - margin, max_x + margin, max_y + margin)
+}
+
+// ── CDT mesh generation ─────────────────────────────────────────────────────
+
+fn build_cdt_mesh(
+    polylines: &[ContourPolyline],
+    min_x: f64,
+    min_y: f64,
+    max_x: f64,
+    max_y: f64,
+) -> (Vec<[f64; 2]>, Vec<[usize; 3]>, Vec<bool>) {
+    let mut cdt = ConstrainedDelaunayTriangulation::<Point2<f64>>::new();
+
+    // Minimum distance between points to avoid degenerate triangles
+    const MIN_DIST_SQ: f64 = 0.5 * 0.5;
+
+    // Track all inserted points for de-duplication
+    let mut inserted_points: Vec<[f64; 2]> = Vec::new();
+
+    // Helper: find or insert a point, returning its vertex handle
+    let find_or_insert =
+        |cdt: &mut ConstrainedDelaunayTriangulation<Point2<f64>>,
+         inserted: &mut Vec<[f64; 2]>,
+         x: f64,
+         y: f64| {
+            // Check for near-duplicate
+            for (idx, p) in inserted.iter().enumerate() {
+                let dx = p[0] - x;
+                let dy = p[1] - y;
+                if dx * dx + dy * dy < MIN_DIST_SQ {
+                    // Return existing handle
+                    let handles: Vec<_> = cdt.vertices().map(|v| v.fix()).collect();
+                    if idx < handles.len() {
+                        return handles[idx];
+                    }
+                }
+            }
+            let handle = cdt.insert(Point2::new(x, y)).expect("CDT insert failed");
+            inserted.push([x, y]);
+            handle
+        };
+
+    // Insert contour vertices and constraints
+    for polyline in polylines {
+        let mut handles = Vec::with_capacity(polyline.points.len());
+        for &[x, y] in &polyline.points {
+            let handle = find_or_insert(&mut cdt, &mut inserted_points, x, y);
+            handles.push(handle);
+        }
+
+        // Add constraint edges along the contour
+        for i in 0..handles.len() {
+            let j = (i + 1) % handles.len();
+            if handles[i] != handles[j] {
+                let _ = cdt.add_constraint(handles[i], handles[j]);
+            }
+        }
+    }
+
+    // Insert boundary rectangle
+    let boundary_handles = [
+        find_or_insert(&mut cdt, &mut inserted_points, min_x, min_y),
+        find_or_insert(&mut cdt, &mut inserted_points, max_x, min_y),
+        find_or_insert(&mut cdt, &mut inserted_points, max_x, max_y),
+        find_or_insert(&mut cdt, &mut inserted_points, min_x, max_y),
+    ];
+
+    // Add boundary constraint edges
+    for i in 0..4 {
+        let j = (i + 1) % 4;
+        if boundary_handles[i] != boundary_handles[j] {
+            let _ = cdt.add_constraint(boundary_handles[i], boundary_handles[j]);
+        }
+    }
+
+    // Extract vertices
+    let vertices: Vec<[f64; 2]> = cdt
+        .vertices()
+        .map(|v| {
+            let p = v.position();
+            [p.x, p.y]
+        })
+        .collect();
+
+    // Build handle-to-index map
+    let handle_to_index: std::collections::HashMap<_, _> = cdt
+        .vertices()
+        .enumerate()
+        .map(|(i, v)| (v.fix(), i))
+        .collect();
+
+    // Extract triangles
+    let triangles: Vec<[usize; 3]> = cdt
+        .inner_faces()
+        .map(|face| {
+            let vs = face.vertices();
+            [
+                handle_to_index[&vs[0].fix()],
+                handle_to_index[&vs[1].fix()],
+                handle_to_index[&vs[2].fix()],
+            ]
+        })
+        .collect();
+
+    // Identify boundary vertices (on domain rectangle edges)
+    let boundary_verts: Vec<bool> = vertices
+        .iter()
+        .map(|v| {
+            let eps = 1.0;
+            (v[0] - min_x).abs() < eps
+                || (v[0] - max_x).abs() < eps
+                || (v[1] - min_y).abs() < eps
+                || (v[1] - max_y).abs() < eps
+        })
+        .collect();
+
+    (vertices, triangles, boundary_verts)
+}
+
+// ── FEM solver ──────────────────────────────────────────────────────────────
+
+fn solve_for_tide_level(
+    vertices: &[[f64; 2]],
+    triangles: &[[usize; 3]],
+    boundary_verts: &[bool],
+    terrain: &TerrainCPUData,
+    contours: &[ParsedContour],
+    _lookup_grid: &ContourLookupGrid,
+    tide_height: f64,
+    min_depth: f64,
+) -> (Vec<f64>, Vec<f64>) {
+    let n = vertices.len();
+
+    // Compute depth at each vertex
+    let depths: Vec<f64> = vertices
+        .iter()
+        .map(|v| {
+            let terrain_h = compute_terrain_height(v[0], v[1], terrain, contours);
+            tide_height - terrain_h
+        })
+        .collect();
+
+    // Classify vertices
+    let is_dry: Vec<bool> = depths.iter().map(|&d| d <= min_depth).collect();
+
+    // Free DOFs: interior wet vertices
+    let mut free_indices: Vec<usize> = Vec::new();
+    let mut vertex_to_free: Vec<Option<usize>> = vec![None; n];
+    for i in 0..n {
+        if !is_dry[i] && !boundary_verts[i] {
+            vertex_to_free[i] = Some(free_indices.len());
+            free_indices.push(i);
+        }
+    }
+
+    let n_free = free_indices.len();
+    if n_free == 0 {
+        // No free DOFs — return zero velocity
+        return (vec![0.0; n * 2], vec![0.0; n * 2]);
+    }
+
+    // Normalize domain for BC values
+    let (domain_min_x, domain_min_y, domain_max_x, domain_max_y) = {
+        let mut mnx = f64::INFINITY;
+        let mut mny = f64::INFINITY;
+        let mut mxx = f64::NEG_INFINITY;
+        let mut mxy = f64::NEG_INFINITY;
+        for v in vertices {
+            mnx = mnx.min(v[0]);
+            mny = mny.min(v[1]);
+            mxx = mxx.max(v[0]);
+            mxy = mxy.max(v[1]);
+        }
+        (mnx, mny, mxx, mxy)
+    };
+    let domain_w = (domain_max_x - domain_min_x).max(1.0);
+    let domain_h = (domain_max_y - domain_min_y).max(1.0);
+
+    // Solve twice: field A (N-S) and field B (E-W)
+    let vel_a = solve_one_field(
+        vertices,
+        triangles,
+        &depths,
+        &is_dry,
+        boundary_verts,
+        &vertex_to_free,
+        &free_indices,
+        n_free,
+        min_depth,
+        // Field A: psi = normalized y on boundary, 0 on dry
+        |i| {
+            if is_dry[i] {
+                0.0
+            } else if boundary_verts[i] {
+                (vertices[i][1] - domain_min_y) / domain_h * 2.0 - 1.0
+            } else {
+                0.0 // free — will be solved
+            }
+        },
+    );
+
+    let vel_b = solve_one_field(
+        vertices,
+        triangles,
+        &depths,
+        &is_dry,
+        boundary_verts,
+        &vertex_to_free,
+        &free_indices,
+        n_free,
+        min_depth,
+        // Field B: psi = normalized x on boundary, 0 on dry
+        |i| {
+            if is_dry[i] {
+                0.0
+            } else if boundary_verts[i] {
+                (vertices[i][0] - domain_min_x) / domain_w * 2.0 - 1.0
+            } else {
+                0.0
+            }
+        },
+    );
+
+    (vel_a, vel_b)
+}
+
+fn solve_one_field(
+    vertices: &[[f64; 2]],
+    triangles: &[[usize; 3]],
+    depths: &[f64],
+    is_dry: &[bool],
+    _boundary_verts: &[bool],
+    vertex_to_free: &[Option<usize>],
+    free_indices: &[usize],
+    n_free: usize,
+    min_depth: f64,
+    bc_value: impl Fn(usize) -> f64,
+) -> Vec<f64> {
+    let n = vertices.len();
+
+    // Prescribed values for all fixed vertices
+    let psi_fixed: Vec<f64> = (0..n).map(|i| bc_value(i)).collect();
+
+    // Assemble stiffness matrix (only free-free block) and RHS
+    let mut triplets: Vec<(usize, usize, f64)> = Vec::new();
+    let mut rhs = vec![0.0; n_free];
+
+    for tri in triangles {
+        let [i0, i1, i2] = *tri;
+
+        // Skip fully dry triangles
+        if is_dry[i0] && is_dry[i1] && is_dry[i2] {
+            continue;
+        }
+
+        let v0 = vertices[i0];
+        let v1 = vertices[i1];
+        let v2 = vertices[i2];
+
+        // Triangle area
+        let area = 0.5
+            * ((v1[0] - v0[0]) * (v2[1] - v0[1]) - (v2[0] - v0[0]) * (v1[1] - v0[1]));
+        let area_abs = area.abs();
+        if area_abs < 1e-10 {
+            continue; // degenerate
+        }
+
+        // Average depth (clamped)
+        let h_avg = ((depths[i0] + depths[i1] + depths[i2]) / 3.0).max(min_depth);
+
+        // Gradient basis functions for P1 elements:
+        // grad(N_i) = (1/(2*area)) * [y_j - y_k, x_k - x_j]
+        let local = [i0, i1, i2];
+        let mut grad = [[0.0f64; 2]; 3];
+        let inv2a = 1.0 / (2.0 * area);
+        grad[0] = [
+            (v1[1] - v2[1]) * inv2a,
+            (v2[0] - v1[0]) * inv2a,
+        ];
+        grad[1] = [
+            (v2[1] - v0[1]) * inv2a,
+            (v0[0] - v2[0]) * inv2a,
+        ];
+        grad[2] = [
+            (v0[1] - v1[1]) * inv2a,
+            (v1[0] - v0[0]) * inv2a,
+        ];
+
+        // Element stiffness: K_e[a][b] = h_avg * area_abs * dot(grad_a, grad_b)
+        for a in 0..3 {
+            let gi = local[a];
+            for b in 0..3 {
+                let gj = local[b];
+                let k_val =
+                    h_avg * area_abs * (grad[a][0] * grad[b][0] + grad[a][1] * grad[b][1]);
+
+                let fi = vertex_to_free[gi];
+                let fj = vertex_to_free[gj];
+
+                match (fi, fj) {
+                    (Some(fi), Some(fj)) => {
+                        // Both free: add to stiffness matrix
+                        triplets.push((fi, fj, k_val));
+                    }
+                    (Some(fi), None) => {
+                        // i is free, j is fixed: contribute to RHS
+                        rhs[fi] -= k_val * psi_fixed[gj];
+                    }
+                    _ => {
+                        // i is fixed: skip
+                    }
+                }
+            }
+        }
+    }
+
+    // Build sparse matrix and solve
+    let psi_free = if n_free > 0 && !triplets.is_empty() {
+        let mut coo = CooMatrix::new(n_free, n_free);
+        for (r, c, v) in &triplets {
+            coo.push(*r, *c, *v);
+        }
+        let csc: nalgebra_sparse::CscMatrix<f64> = (&coo).into();
+
+        // Use Cholesky factorization
+        match nalgebra_sparse::factorization::CscCholesky::factor(&csc) {
+            Ok(cholesky) => {
+                let rhs_vec = nalgebra::DVector::from_vec(rhs);
+                let solution = cholesky.solve(&rhs_vec);
+                solution.as_slice().to_vec()
+            }
+            Err(_) => {
+                // Fallback: return zeros if Cholesky fails (e.g., matrix not SPD)
+                eprintln!(
+                    "Warning: Cholesky factorization failed for tide mesh solve. \
+                     Returning zero flow for this field."
+                );
+                vec![0.0; n_free]
+            }
+        }
+    } else {
+        vec![0.0; n_free]
+    };
+
+    // Reconstruct full psi vector
+    let mut psi = psi_fixed.clone();
+    for (fi, &gi) in free_indices.iter().enumerate() {
+        psi[gi] = psi_free[fi];
+    }
+
+    // Recover velocity per triangle, then smooth to vertices
+    let mut vel_x_sum = vec![0.0; n];
+    let mut vel_y_sum = vec![0.0; n];
+    let mut area_sum = vec![0.0; n];
+
+    for tri in triangles {
+        let [i0, i1, i2] = *tri;
+
+        if is_dry[i0] && is_dry[i1] && is_dry[i2] {
+            continue;
+        }
+
+        let v0 = vertices[i0];
+        let v1 = vertices[i1];
+        let v2 = vertices[i2];
+
+        let area = 0.5
+            * ((v1[0] - v0[0]) * (v2[1] - v0[1]) - (v2[0] - v0[0]) * (v1[1] - v0[1]));
+        let area_abs = area.abs();
+        if area_abs < 1e-10 {
+            continue;
+        }
+
+        let h_avg = ((depths[i0] + depths[i1] + depths[i2]) / 3.0).max(min_depth);
+        let inv2a = 1.0 / (2.0 * area);
+
+        // grad(N_i) for computing dpsi/dx and dpsi/dy
+        let grad0 = [(v1[1] - v2[1]) * inv2a, (v2[0] - v1[0]) * inv2a];
+        let grad1 = [(v2[1] - v0[1]) * inv2a, (v0[0] - v2[0]) * inv2a];
+        let grad2 = [(v0[1] - v1[1]) * inv2a, (v1[0] - v0[0]) * inv2a];
+
+        // dpsi/dx = sum psi_i * grad_i_x
+        let dpsi_dx =
+            psi[i0] * grad0[0] + psi[i1] * grad1[0] + psi[i2] * grad2[0];
+        let dpsi_dy =
+            psi[i0] * grad0[1] + psi[i1] * grad1[1] + psi[i2] * grad2[1];
+
+        // Velocity from stream function: vx = (1/h) * dpsi/dy, vy = -(1/h) * dpsi/dx
+        let vx = dpsi_dy / h_avg;
+        let vy = -dpsi_dx / h_avg;
+
+        // Area-weighted accumulation for vertex averaging
+        for &vi in &[i0, i1, i2] {
+            vel_x_sum[vi] += vx * area_abs;
+            vel_y_sum[vi] += vy * area_abs;
+            area_sum[vi] += area_abs;
+        }
+    }
+
+    // Average and normalize
+    let mut velocity = vec![0.0; n * 2];
+    let mut max_mag = 0.0f64;
+
+    for i in 0..n {
+        if area_sum[i] > 0.0 {
+            velocity[i * 2] = vel_x_sum[i] / area_sum[i];
+            velocity[i * 2 + 1] = vel_y_sum[i] / area_sum[i];
+            let mag = (velocity[i * 2].powi(2) + velocity[i * 2 + 1].powi(2)).sqrt();
+            max_mag = max_mag.max(mag);
+        }
+    }
+
+    // Normalize to unit max magnitude
+    if max_mag > 1e-10 {
+        for v in &mut velocity {
+            *v /= max_mag;
+        }
+    }
+
+    velocity
+}
+
+// ── Spatial grid ────────────────────────────────────────────────────────────
+
+#[allow(clippy::type_complexity)]
+fn build_spatial_grid(
+    vertices: &[[f64; 2]],
+    triangles: &[[usize; 3]],
+    min_x: f64,
+    min_y: f64,
+    max_x: f64,
+    max_y: f64,
+) -> (
+    usize,
+    usize,
+    f64,
+    f64,
+    f64,
+    f64,
+    Vec<u32>,
+    Vec<u32>,
+    Vec<u32>,
+) {
+    let tri_count = triangles.len();
+    if tri_count == 0 {
+        return (1, 1, min_x, min_y, max_x - min_x, max_y - min_y, vec![0], vec![0], vec![]);
+    }
+
+    // Target ~4 triangles per cell
+    let domain_area = (max_x - min_x) * (max_y - min_y);
+    let cell_area = (domain_area / tri_count as f64) * 4.0;
+    let cell_size = cell_area.sqrt().max(1.0);
+
+    let cols = ((max_x - min_x) / cell_size).ceil() as usize;
+    let rows = ((max_y - min_y) / cell_size).ceil() as usize;
+    let cols = cols.max(1).min(1024);
+    let rows = rows.max(1).min(1024);
+
+    let cell_w = (max_x - min_x) / cols as f64;
+    let cell_h = (max_y - min_y) / rows as f64;
+
+    // Assign triangles to cells
+    let cell_count = cols * rows;
+    let mut cell_lists: Vec<Vec<u32>> = vec![Vec::new(); cell_count];
+
+    for (ti, tri) in triangles.iter().enumerate() {
+        let v0 = vertices[tri[0]];
+        let v1 = vertices[tri[1]];
+        let v2 = vertices[tri[2]];
+
+        // Triangle AABB
+        let t_min_x = v0[0].min(v1[0]).min(v2[0]);
+        let t_min_y = v0[1].min(v1[1]).min(v2[1]);
+        let t_max_x = v0[0].max(v1[0]).max(v2[0]);
+        let t_max_y = v0[1].max(v1[1]).max(v2[1]);
+
+        let col_start = ((t_min_x - min_x) / cell_w).floor() as isize;
+        let col_end = ((t_max_x - min_x) / cell_w).floor() as isize;
+        let row_start = ((t_min_y - min_y) / cell_h).floor() as isize;
+        let row_end = ((t_max_y - min_y) / cell_h).floor() as isize;
+
+        for r in row_start.max(0)..=(row_end.min(rows as isize - 1)) {
+            for c in col_start.max(0)..=(col_end.min(cols as isize - 1)) {
+                let cell_idx = r as usize * cols + c as usize;
+                cell_lists[cell_idx].push(ti as u32);
+            }
+        }
+    }
+
+    // Flatten to offset/count format
+    let mut offsets = Vec::with_capacity(cell_count);
+    let mut counts = Vec::with_capacity(cell_count);
+    let mut flat_list: Vec<u32> = Vec::new();
+
+    for cell in &cell_lists {
+        offsets.push(flat_list.len() as u32);
+        counts.push(cell.len() as u32);
+        flat_list.extend_from_slice(cell);
+    }
+
+    (cols, rows, min_x, min_y, cell_w, cell_h, offsets, counts, flat_list)
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+fn empty_tide_mesh(tide_levels: &[f64]) -> TideMeshData {
+    TideMeshData {
+        vertex_positions: vec![],
+        indices: vec![],
+        vertex_count: 0,
+        triangle_count: 0,
+        flow_data: vec![],
+        tide_levels: tide_levels.to_vec(),
+        grid_cols: 1,
+        grid_rows: 1,
+        grid_min_x: 0.0,
+        grid_min_y: 0.0,
+        grid_cell_width: 1.0,
+        grid_cell_height: 1.0,
+        grid_cell_offsets: vec![0],
+        grid_cell_counts: vec![0],
+        grid_triangle_lists: vec![],
+    }
+}

--- a/pipeline/wavemesh-builder/src/tidemesh_file.rs
+++ b/pipeline/wavemesh-builder/src/tidemesh_file.rs
@@ -1,0 +1,159 @@
+//! Binary .tidemesh output format and FNV-1a input hashing.
+
+use crate::level::TerrainCPUData;
+use crate::tidemesh::TideMeshData;
+
+const MAGIC: u32 = 0x4D444954; // "TIDM" little-endian
+const VERSION: u16 = 1;
+const HEADER_BYTES: usize = 64;
+
+/// Serialize tide mesh data into the binary `.tidemesh` format.
+///
+/// Format:
+///   HEADER (64 bytes)
+///   TIDE LEVEL TABLE (4 bytes x tideLevelCount)
+///   VERTEX POSITION DATA (2 * 4 bytes per vertex)
+///   FLOW DATA (tideLevelCount * vertexCount * 4 * 4 bytes)
+///   INDEX DATA (3 * 4 bytes per triangle)
+///   GRID CELL HEADERS (2 * 4 bytes per cell)
+///   GRID TRIANGLE LISTS (4 bytes per entry)
+pub fn build_tidemesh_buffer(mesh: &TideMeshData, input_hash: [u32; 2]) -> Vec<u8> {
+    let tide_level_count = mesh.tide_levels.len();
+    let vertex_count = mesh.vertex_count;
+    let triangle_count = mesh.triangle_count;
+    let grid_cols = mesh.grid_cols;
+    let grid_rows = mesh.grid_rows;
+    let cell_count = grid_cols * grid_rows;
+
+    let tide_table_bytes = tide_level_count * 4;
+    let vertex_pos_bytes = vertex_count * 2 * 4;
+    let flow_data_bytes = tide_level_count * vertex_count * 4 * 4;
+    let index_data_bytes = triangle_count * 3 * 4;
+    let grid_header_bytes = cell_count * 2 * 4;
+    let grid_list_bytes = mesh.grid_triangle_lists.len() * 4;
+
+    let total_size = HEADER_BYTES
+        + tide_table_bytes
+        + vertex_pos_bytes
+        + flow_data_bytes
+        + index_data_bytes
+        + grid_header_bytes
+        + grid_list_bytes;
+
+    let mut buf = vec![0u8; total_size];
+    let mut off;
+
+    // ── Header (64 bytes) ────────────────────────────────────────────────────
+    buf[0..4].copy_from_slice(&MAGIC.to_le_bytes());
+    buf[4..6].copy_from_slice(&VERSION.to_le_bytes());
+    buf[6..8].copy_from_slice(&(tide_level_count as u16).to_le_bytes());
+    buf[8..12].copy_from_slice(&input_hash[0].to_le_bytes());
+    buf[12..16].copy_from_slice(&input_hash[1].to_le_bytes());
+    buf[16..20].copy_from_slice(&(vertex_count as u32).to_le_bytes());
+    buf[20..24].copy_from_slice(&(triangle_count as u32).to_le_bytes());
+    buf[24..28].copy_from_slice(&(grid_cols as u32).to_le_bytes());
+    buf[28..32].copy_from_slice(&(grid_rows as u32).to_le_bytes());
+    buf[32..36].copy_from_slice(&(mesh.grid_min_x as f32).to_le_bytes());
+    buf[36..40].copy_from_slice(&(mesh.grid_min_y as f32).to_le_bytes());
+    buf[40..44].copy_from_slice(&(mesh.grid_cell_width as f32).to_le_bytes());
+    buf[44..48].copy_from_slice(&(mesh.grid_cell_height as f32).to_le_bytes());
+    // [48..63] reserved = 0
+    off = HEADER_BYTES;
+
+    // ── Tide level table ─────────────────────────────────────────────────────
+    for &level in &mesh.tide_levels {
+        buf[off..off + 4].copy_from_slice(&(level as f32).to_le_bytes());
+        off += 4;
+    }
+
+    // ── Vertex position data ─────────────────────────────────────────────────
+    for i in 0..vertex_count {
+        let x = mesh.vertex_positions[i * 2];
+        let y = mesh.vertex_positions[i * 2 + 1];
+        buf[off..off + 4].copy_from_slice(&x.to_le_bytes());
+        off += 4;
+        buf[off..off + 4].copy_from_slice(&y.to_le_bytes());
+        off += 4;
+    }
+
+    // ── Flow data ────────────────────────────────────────────────────────────
+    for &val in &mesh.flow_data {
+        buf[off..off + 4].copy_from_slice(&val.to_le_bytes());
+        off += 4;
+    }
+
+    // ── Index data ───────────────────────────────────────────────────────────
+    for &idx in &mesh.indices {
+        buf[off..off + 4].copy_from_slice(&idx.to_le_bytes());
+        off += 4;
+    }
+
+    // ── Grid cell headers ────────────────────────────────────────────────────
+    for i in 0..cell_count {
+        let cell_offset = mesh.grid_cell_offsets[i];
+        let cell_count = mesh.grid_cell_counts[i];
+        buf[off..off + 4].copy_from_slice(&cell_offset.to_le_bytes());
+        off += 4;
+        buf[off..off + 4].copy_from_slice(&cell_count.to_le_bytes());
+        off += 4;
+    }
+
+    // ── Grid triangle lists ──────────────────────────────────────────────────
+    for &tri_idx in &mesh.grid_triangle_lists {
+        buf[off..off + 4].copy_from_slice(&tri_idx.to_le_bytes());
+        off += 4;
+    }
+
+    debug_assert_eq!(off, total_size);
+
+    buf
+}
+
+/// FNV-1a 32-bit hash.
+fn fnv1a_32(parts: &[&[u8]], offset_basis: u32) -> u32 {
+    let mut h = offset_basis;
+    for part in parts {
+        for &b in *part {
+            h ^= b as u32;
+            h = h.wrapping_mul(0x01000193);
+        }
+    }
+    h
+}
+
+fn f64_bytes(v: f64) -> [u8; 8] {
+    v.to_le_bytes()
+}
+
+/// Compute a 64-bit FNV-1a hash of terrain data and tide levels for cache
+/// invalidation. Returns `[hash_lo, hash_hi]`.
+pub fn compute_tide_input_hash(terrain: &TerrainCPUData, tide_levels: &[f64]) -> [u32; 2] {
+    let vertex_bytes: Vec<u8> = terrain
+        .vertex_data
+        .iter()
+        .flat_map(|f| f.to_le_bytes())
+        .collect();
+    let children_bytes: Vec<u8> = terrain
+        .children_data
+        .iter()
+        .flat_map(|u| u.to_le_bytes())
+        .collect();
+    let contour_count_bytes = f64_bytes(terrain.contour_count as f64);
+    let default_depth_bytes = f64_bytes(terrain.default_depth);
+    let tide_level_bytes: Vec<u8> = tide_levels
+        .iter()
+        .flat_map(|t| t.to_le_bytes())
+        .collect();
+
+    let parts: Vec<Vec<u8>> = vec![
+        vertex_bytes,
+        terrain.contour_data.clone(),
+        children_bytes,
+        contour_count_bytes.to_vec(),
+        default_depth_bytes.to_vec(),
+        tide_level_bytes,
+    ];
+
+    let refs: Vec<&[u8]> = parts.iter().map(|p| p.as_slice()).collect();
+    [fnv1a_32(&refs, 0x811c9dc5), fnv1a_32(&refs, 0x050c5d1f)]
+}

--- a/src/game/world/shaders/tide-mesh-packed.wgsl.ts
+++ b/src/game/world/shaders/tide-mesh-packed.wgsl.ts
@@ -1,0 +1,256 @@
+/**
+ * Packed tide mesh accessor functions for reading from a single array<u32> buffer.
+ *
+ * Buffer layout matches TideMeshPacking.ts:
+ *
+ * HEADER (16 u32s):
+ *   [0]  tideLevelCount
+ *   [1]  vertexCount
+ *   [2]  triangleCount
+ *   [3]  gridCols
+ *   [4]  gridRows
+ *   [5]  gridMinX (f32 as u32)
+ *   [6]  gridMinY (f32 as u32)
+ *   [7]  gridCellWidth (f32 as u32)
+ *   [8]  gridCellHeight (f32 as u32)
+ *   [9]  tideLevelTableOffset
+ *   [10] vertexDataOffset
+ *   [11] flowDataOffset
+ *   [12] indexDataOffset
+ *   [13] gridCellHeadersOffset
+ *   [14] gridTriangleListsOffset
+ *   [15] padding
+ *
+ * DATA SECTIONS:
+ *   Tide level table: tideLevelCount f32s (as u32 bitcast)
+ *   Vertex positions: vertexCount * 2 f32s (as u32)
+ *   Flow data: tideLevelCount * vertexCount * 4 f32s (as u32) — (vx_a, vy_a, vx_b, vy_b)
+ *   Index data: triangleCount * 3 u32s
+ *   Grid cell headers: gridCols * gridRows * 2 u32s (offset, count)
+ *   Grid triangle lists: variable u32s
+ *
+ * All float values are stored as u32 and recovered via bitcast<f32>().
+ */
+
+import type { ShaderModule } from "../../../core/graphics/webgpu/ShaderModule";
+import { fn_barycentric } from "./mesh-packed.wgsl";
+
+/**
+ * Bitcast a u32 from the packed buffer to f32.
+ */
+export const fn_tideMeshReadF32: ShaderModule = {
+  code: /*wgsl*/ `
+fn tideMeshReadF32(packed: ptr<storage, array<u32>, read>, index: u32) -> f32 {
+  return bitcast<f32>((*packed)[index]);
+}
+`,
+};
+
+/**
+ * Read a vertex position from the tide mesh vertex data.
+ * Each vertex is 2 f32s: [posX, posY].
+ */
+export const fn_tideMeshGetVertex: ShaderModule = {
+  dependencies: [fn_tideMeshReadF32],
+  code: /*wgsl*/ `
+fn tideMeshGetVertex(packed: ptr<storage, array<u32>, read>, vertexDataOffset: u32, idx: u32) -> vec2<f32> {
+  let base = vertexDataOffset + idx * 2u;
+  return vec2<f32>(
+    tideMeshReadF32(packed, base),
+    tideMeshReadF32(packed, base + 1u)
+  );
+}
+`,
+};
+
+/**
+ * Read flow data for a vertex at a given tide level.
+ * Flow data layout per vertex per tide level: 4 f32s (vx_a, vy_a, vx_b, vy_b).
+ * Returns vec4(vx_a, vy_a, vx_b, vy_b).
+ */
+export const fn_tideMeshGetFlow: ShaderModule = {
+  dependencies: [fn_tideMeshReadF32],
+  code: /*wgsl*/ `
+fn tideMeshGetFlow(
+  packed: ptr<storage, array<u32>, read>,
+  flowDataOffset: u32,
+  vertexCount: u32,
+  tideLevelIdx: u32,
+  vertexIdx: u32,
+) -> vec4<f32> {
+  let base = flowDataOffset + (tideLevelIdx * vertexCount + vertexIdx) * 4u;
+  return vec4<f32>(
+    tideMeshReadF32(packed, base),
+    tideMeshReadF32(packed, base + 1u),
+    tideMeshReadF32(packed, base + 2u),
+    tideMeshReadF32(packed, base + 3u)
+  );
+}
+`,
+};
+
+/**
+ * Barycentric coordinate computation for tidal flow lookup.
+ * Reuses the shared barycentric function from mesh-packed.wgsl.ts.
+ */
+export const fn_tidalFlowBarycentric: ShaderModule = {
+  dependencies: [fn_barycentric],
+  code: "",
+};
+
+/**
+ * Look up tidal flow velocity at a world position.
+ *
+ * Uses spatial grid for efficient triangle search, then barycentric interpolation
+ * across tide levels and orthogonal flow fields.
+ *
+ * Algorithm:
+ * 1. Read header from packed buffer
+ * 2. Map world position to grid cell (axis-aligned)
+ * 3. Search triangles in grid cell via barycentric containment test
+ * 4. Interpolate flow between bracketing tide levels
+ * 5. Blend orthogonal flow fields A and B using tidalPhase
+ * 6. Scale by tidalStrength
+ */
+export const fn_lookupTidalFlow: ShaderModule = {
+  dependencies: [
+    fn_tideMeshReadF32,
+    fn_tideMeshGetVertex,
+    fn_tideMeshGetFlow,
+    fn_barycentric,
+  ],
+  code: /*wgsl*/ `
+fn lookupTidalFlow(
+  worldPos: vec2<f32>,
+  packedTide: ptr<storage, array<u32>, read>,
+  tideHeight: f32,
+  tidalPhase: f32,
+  tidalStrength: f32,
+) -> vec2<f32> {
+  // Read header
+  let tideLevelCount = (*packedTide)[0u];
+  let vertexCount = (*packedTide)[1u];
+  let triangleCount = (*packedTide)[2u];
+  let gridCols = (*packedTide)[3u];
+  let gridRows = (*packedTide)[4u];
+  let gridMinX = tideMeshReadF32(packedTide, 5u);
+  let gridMinY = tideMeshReadF32(packedTide, 6u);
+  let gridCellWidth = tideMeshReadF32(packedTide, 7u);
+  let gridCellHeight = tideMeshReadF32(packedTide, 8u);
+  let tideLevelTableOffset = (*packedTide)[9u];
+  let vertexDataOffset = (*packedTide)[10u];
+  let flowDataOffset = (*packedTide)[11u];
+  let indexDataOffset = (*packedTide)[12u];
+  let gridCellHeadersOffset = (*packedTide)[13u];
+  let gridTriangleListsOffset = (*packedTide)[14u];
+
+  if (tideLevelCount == 0u) {
+    return vec2<f32>(0.0, 0.0);
+  }
+
+  // Map world position to grid cell (axis-aligned, no rotation)
+  let gx = (worldPos.x - gridMinX) / gridCellWidth;
+  let gy = (worldPos.y - gridMinY) / gridCellHeight;
+
+  let col = i32(floor(gx));
+  let row = i32(floor(gy));
+
+  // Bounds check
+  if (col < 0 || col >= i32(gridCols) || row < 0 || row >= i32(gridRows)) {
+    return vec2<f32>(0.0, 0.0);
+  }
+
+  // Read cell header (offset, count)
+  let cellIndex = u32(row) * gridCols + u32(col);
+  let cellBase = gridCellHeadersOffset + cellIndex * 2u;
+  let triListOffset = (*packedTide)[cellBase];
+  let triListCount = (*packedTide)[cellBase + 1u];
+
+  // Search triangles in this cell
+  for (var t = 0u; t < triListCount; t++) {
+    let triIndex = (*packedTide)[triListOffset + t];
+
+    // Read 3 vertex indices
+    let idxBase = indexDataOffset + triIndex * 3u;
+    let i0 = (*packedTide)[idxBase];
+    let i1 = (*packedTide)[idxBase + 1u];
+    let i2 = (*packedTide)[idxBase + 2u];
+
+    // Read vertex positions
+    let v0 = tideMeshGetVertex(packedTide, vertexDataOffset, i0);
+    let v1 = tideMeshGetVertex(packedTide, vertexDataOffset, i1);
+    let v2 = tideMeshGetVertex(packedTide, vertexDataOffset, i2);
+
+    // Compute barycentric coordinates
+    let bary = barycentric(worldPos, v0, v1, v2);
+
+    // Check if point is inside triangle (with small tolerance)
+    if (bary.x >= -0.001 && bary.y >= -0.001 && bary.z >= -0.001) {
+      // Find bracketing tide levels
+      var lowerIdx = 0u;
+      var upperIdx = 0u;
+      var interpT = 0.0f;
+
+      if (tideLevelCount == 1u) {
+        lowerIdx = 0u;
+        upperIdx = 0u;
+        interpT = 0.0;
+      } else {
+        // Read tide levels to find bracket
+        let firstLevel = tideMeshReadF32(packedTide, tideLevelTableOffset);
+        let lastLevel = tideMeshReadF32(packedTide, tideLevelTableOffset + tideLevelCount - 1u);
+
+        if (tideHeight <= firstLevel) {
+          lowerIdx = 0u;
+          upperIdx = 0u;
+          interpT = 0.0;
+        } else if (tideHeight >= lastLevel) {
+          lowerIdx = tideLevelCount - 1u;
+          upperIdx = tideLevelCount - 1u;
+          interpT = 0.0;
+        } else {
+          // Search for bracket
+          for (var li = 0u; li < tideLevelCount - 1u; li++) {
+            let levelLow = tideMeshReadF32(packedTide, tideLevelTableOffset + li);
+            let levelHigh = tideMeshReadF32(packedTide, tideLevelTableOffset + li + 1u);
+            if (tideHeight >= levelLow && tideHeight <= levelHigh) {
+              lowerIdx = li;
+              upperIdx = li + 1u;
+              let range = levelHigh - levelLow;
+              if (abs(range) > 1e-6) {
+                interpT = (tideHeight - levelLow) / range;
+              }
+              break;
+            }
+          }
+        }
+      }
+
+      // Read and interpolate flow at the lower tide level
+      let flowA0 = tideMeshGetFlow(packedTide, flowDataOffset, vertexCount, lowerIdx, i0);
+      let flowA1 = tideMeshGetFlow(packedTide, flowDataOffset, vertexCount, lowerIdx, i1);
+      let flowA2 = tideMeshGetFlow(packedTide, flowDataOffset, vertexCount, lowerIdx, i2);
+      let flowLower = flowA0 * bary.x + flowA1 * bary.y + flowA2 * bary.z;
+
+      // Read and interpolate flow at the upper tide level
+      let flowB0 = tideMeshGetFlow(packedTide, flowDataOffset, vertexCount, upperIdx, i0);
+      let flowB1 = tideMeshGetFlow(packedTide, flowDataOffset, vertexCount, upperIdx, i1);
+      let flowB2 = tideMeshGetFlow(packedTide, flowDataOffset, vertexCount, upperIdx, i2);
+      let flowUpper = flowB0 * bary.x + flowB1 * bary.y + flowB2 * bary.z;
+
+      // Lerp between tide levels
+      let flow = mix(flowLower, flowUpper, interpT);
+
+      // Blend orthogonal fields: field A (cos) + field B (sin)
+      let vx = flow.x * cos(tidalPhase) + flow.z * sin(tidalPhase);
+      let vy = flow.y * cos(tidalPhase) + flow.w * sin(tidalPhase);
+
+      return vec2<f32>(vx, vy) * tidalStrength;
+    }
+  }
+
+  // No containing triangle found
+  return vec2<f32>(0.0, 0.0);
+}
+`,
+};

--- a/src/game/world/water/TidalResources.ts
+++ b/src/game/world/water/TidalResources.ts
@@ -1,0 +1,119 @@
+/**
+ * Tidal flow resource manager.
+ *
+ * Singleton entity that loads tidal flow mesh data and provides GPU buffers
+ * and tidal state (phase, strength) for query shaders and rendering.
+ *
+ * Tidal phase advances based on game-world time from TimeOfDay, following
+ * a semi-diurnal tidal cycle (~12.42 hours per cycle).
+ */
+
+import { BaseEntity } from "../../../core/entity/BaseEntity";
+import { on } from "../../../core/entity/handler";
+import type { TideMeshFileData } from "../../../pipeline/mesh-building/TidemeshFile";
+import { TimeOfDay } from "../../time/TimeOfDay";
+import {
+  packTideMeshBuffer,
+  createPlaceholderTideMeshBuffer,
+} from "./TideMeshPacking";
+import { loadTidemeshFromUrl } from "./TidemeshLoader";
+
+/** Semi-diurnal tidal period in seconds (~12.42 hours) */
+const TIDAL_PERIOD_SECONDS = 12.42 * 3600;
+
+/**
+ * Singleton entity that manages tidal flow mesh data and tidal state.
+ */
+export class TidalResources extends BaseEntity {
+  id = "tidalResources";
+  tickLayer = "query" as const;
+
+  private packedBuffer: Uint32Array;
+  private gpuBuffer: GPUBuffer | null = null;
+  private tidalPhase: number = 0;
+  private tidalStrength: number = 1.5; // ft/s max current speed
+  private loaded: boolean = false;
+
+  constructor() {
+    super();
+    this.packedBuffer = createPlaceholderTideMeshBuffer();
+  }
+
+  /**
+   * Load tidal flow mesh data from a URL.
+   */
+  async loadTidemesh(url: string): Promise<void> {
+    const data: TideMeshFileData = await loadTidemeshFromUrl(url);
+    this.packedBuffer = packTideMeshBuffer(data);
+    this.loaded = true;
+    // GPU buffer will be recreated on next access
+    this.gpuBuffer?.destroy();
+    this.gpuBuffer = null;
+  }
+
+  /**
+   * Get or create the packed GPU buffer for binding in query/render shaders.
+   */
+  getPackedBuffer(device: GPUDevice): GPUBuffer {
+    if (!this.gpuBuffer) {
+      this.gpuBuffer = device.createBuffer({
+        size: this.packedBuffer.byteLength,
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+        label: "tidemesh-packed",
+      });
+      device.queue.writeBuffer(this.gpuBuffer, 0, this.packedBuffer);
+    }
+    return this.gpuBuffer;
+  }
+
+  /**
+   * Get the current tidal phase (0..2*PI over one tidal cycle).
+   */
+  getTidalPhase(): number {
+    return this.tidalPhase;
+  }
+
+  /**
+   * Get the tidal strength scale factor (ft/s).
+   */
+  getTidalStrength(): number {
+    return this.tidalStrength;
+  }
+
+  /**
+   * Set the tidal strength scale factor (ft/s).
+   */
+  setTidalStrength(strength: number): void {
+    this.tidalStrength = strength;
+  }
+
+  /**
+   * Whether tidal mesh data has been loaded.
+   */
+  isLoaded(): boolean {
+    return this.loaded;
+  }
+
+  /**
+   * Update tidal phase from game-world time each tick.
+   *
+   * Semi-diurnal tide: ~12.42 hour period.
+   * tidalPhase rotates 0..2*PI over one tidal cycle.
+   */
+  @on("tick")
+  onTick() {
+    const timeOfDay = this.game.entities.tryGetSingleton(TimeOfDay);
+    if (timeOfDay) {
+      const timeInSeconds = timeOfDay.getTimeInSeconds();
+      this.tidalPhase =
+        ((timeInSeconds / TIDAL_PERIOD_SECONDS) * Math.PI * 2) %
+        (Math.PI * 2);
+    }
+  }
+
+  @on("destroy")
+  onDestroy(): void {
+    this.gpuBuffer?.destroy();
+    this.gpuBuffer = null;
+  }
+}

--- a/src/game/world/water/TideMeshPacking.ts
+++ b/src/game/world/water/TideMeshPacking.ts
@@ -1,0 +1,169 @@
+/**
+ * CPU-side tide mesh packing for GPU compute shader access.
+ *
+ * Packs tidal flow vertex/index data and spatial grid indices into a single
+ * array<u32> buffer.
+ *
+ * Buffer layout:
+ * HEADER (16 u32s):
+ *   [0]  tideLevelCount
+ *   [1]  vertexCount
+ *   [2]  triangleCount
+ *   [3]  gridCols
+ *   [4]  gridRows
+ *   [5]  gridMinX (f32 as u32)
+ *   [6]  gridMinY (f32 as u32)
+ *   [7]  gridCellWidth (f32 as u32)
+ *   [8]  gridCellHeight (f32 as u32)
+ *   [9]  tideLevelTableOffset (u32 offset into buffer)
+ *   [10] vertexDataOffset
+ *   [11] flowDataOffset
+ *   [12] indexDataOffset
+ *   [13] gridCellHeadersOffset
+ *   [14] gridTriangleListsOffset
+ *   [15] padding
+ *
+ * DATA SECTIONS (packed sequentially after header):
+ *   Tide level table: tideLevelCount f32s (as u32 bitcast)
+ *   Vertex positions: vertexCount * 2 f32s (as u32)
+ *   Flow data: tideLevelCount * vertexCount * 4 f32s (as u32)
+ *   Index data: triangleCount * 3 u32s
+ *   Grid cell headers: gridCols * gridRows * 2 u32s
+ *   Grid triangle lists: variable u32s
+ */
+
+import type { TideMeshFileData } from "../../../pipeline/mesh-building/TidemeshFile";
+
+const HEADER_U32S = 16;
+
+/** Float bits -> u32 for buffer packing */
+function f32AsU32(f: number): number {
+  const buf = new Float32Array(1);
+  buf[0] = f;
+  return new Uint32Array(buf.buffer)[0];
+}
+
+export function packTideMeshBuffer(data: TideMeshFileData): Uint32Array {
+  const {
+    tideLevels,
+    vertexPositions,
+    flowData,
+    indices,
+    vertexCount,
+    triangleCount,
+    gridCols,
+    gridRows,
+    gridMinX,
+    gridMinY,
+    gridCellWidth,
+    gridCellHeight,
+    gridCellHeaders,
+    gridTriangleLists,
+  } = data;
+
+  const tideLevelCount = tideLevels.length;
+  const tideLevelU32s = tideLevelCount;
+  const vertexU32s = vertexCount * 2;
+  const flowU32s = tideLevelCount * vertexCount * 4;
+  const indexU32s = triangleCount * 3;
+  const gridHeaderU32s = gridCols * gridRows * 2;
+  const gridListU32s = gridTriangleLists.length;
+
+  const totalU32s =
+    HEADER_U32S +
+    tideLevelU32s +
+    vertexU32s +
+    flowU32s +
+    indexU32s +
+    gridHeaderU32s +
+    gridListU32s;
+
+  const buffer = new ArrayBuffer(totalU32s * 4);
+  const u32View = new Uint32Array(buffer);
+  const f32View = new Float32Array(buffer);
+
+  // Calculate offsets
+  let currentOffset = HEADER_U32S;
+
+  const tideLevelTableOffset = currentOffset;
+  currentOffset += tideLevelU32s;
+
+  const vertexDataOffset = currentOffset;
+  currentOffset += vertexU32s;
+
+  const flowDataOffset = currentOffset;
+  currentOffset += flowU32s;
+
+  const indexDataOffset = currentOffset;
+  currentOffset += indexU32s;
+
+  const gridCellHeadersOffset = currentOffset;
+  currentOffset += gridHeaderU32s;
+
+  const gridTriangleListsOffset = currentOffset;
+
+  // Write header
+  u32View[0] = tideLevelCount;
+  u32View[1] = vertexCount;
+  u32View[2] = triangleCount;
+  u32View[3] = gridCols;
+  u32View[4] = gridRows;
+  u32View[5] = f32AsU32(gridMinX);
+  u32View[6] = f32AsU32(gridMinY);
+  u32View[7] = f32AsU32(gridCellWidth);
+  u32View[8] = f32AsU32(gridCellHeight);
+  u32View[9] = tideLevelTableOffset;
+  u32View[10] = vertexDataOffset;
+  u32View[11] = flowDataOffset;
+  u32View[12] = indexDataOffset;
+  u32View[13] = gridCellHeadersOffset;
+  u32View[14] = gridTriangleListsOffset;
+  u32View[15] = 0; // padding
+
+  // Write tide level table
+  for (let i = 0; i < tideLevelCount; i++) {
+    f32View[tideLevelTableOffset + i] = tideLevels[i];
+  }
+
+  // Write vertex positions
+  for (let i = 0; i < vertexCount * 2; i++) {
+    f32View[vertexDataOffset + i] = vertexPositions[i];
+  }
+
+  // Write flow data
+  let flowOffset = flowDataOffset;
+  for (let t = 0; t < tideLevelCount; t++) {
+    const tideFlowData = flowData[t];
+    for (let i = 0; i < vertexCount * 4; i++) {
+      f32View[flowOffset + i] = tideFlowData[i];
+    }
+    flowOffset += vertexCount * 4;
+  }
+
+  // Write index data
+  for (let i = 0; i < triangleCount * 3; i++) {
+    u32View[indexDataOffset + i] = indices[i];
+  }
+
+  // Write grid cell headers — adjust triListOffsets to be absolute u32 indices
+  const cellCount = gridCols * gridRows;
+  for (let i = 0; i < cellCount; i++) {
+    const rawOffset = gridCellHeaders[i * 2]; // relative to grid triangle lists
+    const count = gridCellHeaders[i * 2 + 1];
+    u32View[gridCellHeadersOffset + i * 2] = gridTriangleListsOffset + rawOffset;
+    u32View[gridCellHeadersOffset + i * 2 + 1] = count;
+  }
+
+  // Write grid triangle lists
+  for (let i = 0; i < gridListU32s; i++) {
+    u32View[gridTriangleListsOffset + i] = gridTriangleLists[i];
+  }
+
+  return new Uint32Array(buffer);
+}
+
+export function createPlaceholderTideMeshBuffer(): Uint32Array {
+  const buffer = new Uint32Array(HEADER_U32S);
+  // All zeros: tideLevelCount=0, vertexCount=0, triangleCount=0, etc.
+  return buffer;
+}

--- a/src/game/world/water/TidemeshLoader.ts
+++ b/src/game/world/water/TidemeshLoader.ts
@@ -1,0 +1,15 @@
+import type { TideMeshFileData } from "../../../pipeline/mesh-building/TidemeshFile";
+import { parseTidemeshBuffer } from "../../../pipeline/mesh-building/TidemeshFile";
+
+export async function loadTidemeshFromUrl(
+  url: string,
+): Promise<TideMeshFileData> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch tidemesh: ${response.status} ${response.statusText}`,
+    );
+  }
+  const buffer = await response.arrayBuffer();
+  return parseTidemeshBuffer(buffer);
+}

--- a/src/game/world/water/WaterQueryManager.ts
+++ b/src/game/world/water/WaterQueryManager.ts
@@ -3,6 +3,8 @@ import type { ComputeShader } from "../../../core/graphics/webgpu/ComputeShader"
 
 import { createPlaceholderPackedMeshBuffer } from "../../wave-physics/MeshPacking";
 import { WavePhysicsResources } from "../../wave-physics/WavePhysicsResources";
+import { createPlaceholderTideMeshBuffer } from "./TideMeshPacking";
+import { TidalResources } from "./TidalResources";
 import { BaseQuery } from "../query/BaseQuery";
 import { QueryManager } from "../query/QueryManager";
 import { DEFAULT_DEPTH } from "../terrain/TerrainConstants";
@@ -27,6 +29,7 @@ export class WaterQueryManager extends QueryManager {
   private queryShader: ComputeShader | null = null;
   private uniformBuffer: GPUBuffer | null = null;
   private placeholderPackedMeshBuffer: GPUBuffer | null = null;
+  private placeholderTideMeshBuffer: GPUBuffer | null = null;
   private uniforms = WaterQueryUniforms.create();
 
   constructor() {
@@ -53,6 +56,18 @@ export class WaterQueryManager extends QueryManager {
     // Create placeholder packed mesh buffer (empty - no wave sources)
     this.placeholderPackedMeshBuffer = createPlaceholderPackedMeshBuffer(
       this.game.getWebGPUDevice(),
+    );
+
+    // Create placeholder tide mesh buffer (empty - no tidal data)
+    this.placeholderTideMeshBuffer = device.createBuffer({
+      label: "Placeholder Tide Mesh Buffer",
+      size: createPlaceholderTideMeshBuffer().byteLength,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+    });
+    device.queue.writeBuffer(
+      this.placeholderTideMeshBuffer,
+      0,
+      createPlaceholderTideMeshBuffer(),
     );
   }
 
@@ -90,6 +105,12 @@ export class WaterQueryManager extends QueryManager {
     const tideHeight = waterResources.getTideHeight();
     const modifierCount = waterResources.getModifierCount();
 
+    const tidalResources =
+      this.game.entities.tryGetSingleton(TidalResources);
+    const packedTideMeshBuffer =
+      tidalResources?.getPackedBuffer(this.game.getWebGPUDevice()) ??
+      this.placeholderTideMeshBuffer!;
+
     this.uniforms.set.pointCount(pointCount);
     this.uniforms.set.time(performance.now() / 1000);
     this.uniforms.set.tideHeight(tideHeight);
@@ -97,8 +118,8 @@ export class WaterQueryManager extends QueryManager {
     this.uniforms.set.contourCount(terrainResources.getContourCount());
     this.uniforms.set.defaultDepth(DEFAULT_DEPTH);
     this.uniforms.set.numWaves(waterResources.getNumWaves());
-    this.uniforms.set._padding0(0);
-    this.uniforms.set._padding1(0);
+    this.uniforms.set.tidalPhase(tidalResources?.getTidalPhase() ?? 0);
+    this.uniforms.set.tidalStrength(tidalResources?.getTidalStrength() ?? 0);
     this.uniforms.set._padding2(0);
     this.uniforms.set._padding3(0);
     this.uniforms.set._padding4(0);
@@ -110,6 +131,7 @@ export class WaterQueryManager extends QueryManager {
       modifiers: { buffer: waterResources.modifiersBuffer },
       packedMesh: { buffer: packedMeshBuffer },
       packedTerrain: { buffer: terrainResources.packedTerrainBuffer },
+      packedTideMesh: { buffer: packedTideMeshBuffer },
       pointBuffer: { buffer: this.pointBuffer },
       resultBuffer: { buffer: this.resultBuffer },
     });
@@ -127,5 +149,6 @@ export class WaterQueryManager extends QueryManager {
   onDestroy(): void {
     this.uniformBuffer?.destroy();
     this.placeholderPackedMeshBuffer?.destroy();
+    this.placeholderTideMeshBuffer?.destroy();
   }
 }

--- a/src/game/world/water/WaterQueryShader.ts
+++ b/src/game/world/water/WaterQueryShader.ts
@@ -26,6 +26,7 @@ import {
   fn_computeTerrainHeight,
   struct_ContourData,
 } from "../shaders/terrain.wgsl";
+import { fn_lookupTidalFlow } from "../shaders/tide-mesh-packed.wgsl";
 import { fn_calculateModifiers } from "../shaders/water-modifiers.wgsl";
 import {
   GERSTNER_STEEPNESS,
@@ -49,8 +50,8 @@ export const WaterQueryUniforms = defineUniformStruct("Params", {
   contourCount: u32,
   defaultDepth: f32,
   numWaves: u32,
-  _padding0: f32,
-  _padding1: f32,
+  tidalPhase: f32,
+  tidalStrength: f32,
   _padding2: f32,
   _padding3: f32,
   _padding4: f32,
@@ -71,8 +72,8 @@ struct Params {
   contourCount: u32,
   defaultDepth: f32,
   numWaves: u32,
-  _padding0: f32,
-  _padding1: f32,
+  tidalPhase: f32,
+  tidalStrength: f32,
   _padding2: f32,
   _padding3: f32,
   _padding4: f32,
@@ -94,6 +95,7 @@ struct WaterQueryResult {
     modifiers: { type: "storage", wgslType: "array<f32>" },
     packedMesh: { type: "storage", wgslType: "array<u32>" },
     packedTerrain: { type: "storage", wgslType: "array<u32>" },
+    packedTideMesh: { type: "storage", wgslType: "array<u32>" },
     pointBuffer: { type: "storage", wgslType: "array<vec2<f32>>" },
     resultBuffer: { type: "storageRW", wgslType: "array<WaterQueryResult>" },
   },
@@ -111,6 +113,7 @@ const waterQueryMainModule: ShaderModule = {
     fn_calculateModifiers,
     fn_lookupMeshForWave,
     fn_computeTerrainHeight,
+    fn_lookupTidalFlow,
   ],
   code: /*wgsl*/ `
 // Constants
@@ -233,10 +236,19 @@ fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
   let finalSurfaceHeight = surfaceHeight + modifierResult.x;
   let finalDepth = finalSurfaceHeight - terrainHeight;
 
+  // Sample tidal flow from precomputed mesh
+  let tidalVel = lookupTidalFlow(
+    queryPoint,
+    &packedTideMesh,
+    params.tideHeight,
+    params.tidalPhase,
+    params.tidalStrength,
+  );
+
   var result: WaterQueryResult;
   result.surfaceHeight = finalSurfaceHeight;
-  result.velocityX = modifierResult.y;
-  result.velocityY = modifierResult.z;
+  result.velocityX = modifierResult.y + tidalVel.x;
+  result.velocityY = modifierResult.z + tidalVel.y;
   result.normalX = normal.x;
   result.normalY = normal.y;
   result.depth = finalDepth;

--- a/src/pipeline/mesh-building/TidemeshFile.ts
+++ b/src/pipeline/mesh-building/TidemeshFile.ts
@@ -1,0 +1,133 @@
+/**
+ * Binary .tidemesh file format for prebuilt tidal flow mesh data.
+ *
+ * Format:
+ *   Header (64 bytes):
+ *     [0..3]    magic: u32 = 0x4D444954 ("TIDM" LE)
+ *     [4..5]    version: u16 = 1
+ *     [6..7]    tideLevelCount: u16
+ *     [8..11]   inputHash[0]: u32
+ *     [12..15]  inputHash[1]: u32
+ *     [16..19]  vertexCount: u32
+ *     [20..23]  triangleCount: u32
+ *     [24..27]  gridCols: u32
+ *     [28..31]  gridRows: u32
+ *     [32..35]  gridMinX: f32
+ *     [36..39]  gridMinY: f32
+ *     [40..43]  gridCellWidth: f32
+ *     [44..47]  gridCellHeight: f32
+ *     [48..63]  reserved
+ *
+ *   Tide level table (4 bytes x tideLevelCount):
+ *     tideHeight: f32
+ *
+ *   Vertex position data (2 f32 per vertex):
+ *     x, y
+ *
+ *   Flow data (tideLevelCount * vertexCount * 4 f32):
+ *     For each tide level, for each vertex: vx_a, vy_a, vx_b, vy_b
+ *
+ *   Index data (3 u32 per triangle):
+ *     i0, i1, i2
+ *
+ *   Grid cell headers (2 u32 per cell, gridCols * gridRows cells):
+ *     triListOffset, triListCount
+ *
+ *   Grid triangle lists (u32 per entry):
+ *     triangleIndex
+ */
+
+const MAGIC = 0x4d444954; // "TIDM" as little-endian u32
+const HEADER_BYTES = 64;
+
+export interface TideMeshFileData {
+  tideLevels: Float32Array;
+  vertexPositions: Float32Array; // vertexCount * 2
+  flowData: Float32Array[]; // tideLevelCount arrays, each vertexCount * 4
+  indices: Uint32Array; // triangleCount * 3
+  vertexCount: number;
+  triangleCount: number;
+  gridCols: number;
+  gridRows: number;
+  gridMinX: number;
+  gridMinY: number;
+  gridCellWidth: number;
+  gridCellHeight: number;
+  gridCellHeaders: Uint32Array; // (gridCols * gridRows) * 2
+  gridTriangleLists: Uint32Array;
+}
+
+export function parseTidemeshBuffer(buffer: ArrayBuffer): TideMeshFileData {
+  const view = new DataView(buffer);
+
+  const magic = view.getUint32(0, true);
+  if (magic !== MAGIC) {
+    throw new Error(
+      `Invalid tidemesh magic: 0x${magic.toString(16)} (expected 0x${MAGIC.toString(16)})`,
+    );
+  }
+
+  const version = view.getUint16(4, true);
+  if (version !== 1) {
+    throw new Error(`Unsupported tidemesh version: ${version}`);
+  }
+
+  const tideLevelCount = view.getUint16(6, true);
+  const vertexCount = view.getUint32(16, true);
+  const triangleCount = view.getUint32(20, true);
+  const gridCols = view.getUint32(24, true);
+  const gridRows = view.getUint32(28, true);
+  const gridMinX = view.getFloat32(32, true);
+  const gridMinY = view.getFloat32(36, true);
+  const gridCellWidth = view.getFloat32(40, true);
+  const gridCellHeight = view.getFloat32(44, true);
+
+  let offset = HEADER_BYTES;
+
+  // Tide level table
+  const tideLevels = new Float32Array(buffer, offset, tideLevelCount);
+  offset += tideLevelCount * 4;
+
+  // Vertex positions
+  const vertexPositions = new Float32Array(buffer, offset, vertexCount * 2);
+  offset += vertexCount * 2 * 4;
+
+  // Flow data: tideLevelCount arrays, each vertexCount * 4 floats
+  const flowData: Float32Array[] = [];
+  for (let t = 0; t < tideLevelCount; t++) {
+    const floatCount = vertexCount * 4;
+    flowData.push(new Float32Array(buffer, offset, floatCount));
+    offset += floatCount * 4;
+  }
+
+  // Index data
+  const indexCount = triangleCount * 3;
+  const indices = new Uint32Array(buffer, offset, indexCount);
+  offset += indexCount * 4;
+
+  // Grid cell headers
+  const numCells = gridCols * gridRows;
+  const gridCellHeaders = new Uint32Array(buffer, offset, numCells * 2);
+  offset += numCells * 2 * 4;
+
+  // Grid triangle lists (remaining data)
+  const remainingU32s = (buffer.byteLength - offset) / 4;
+  const gridTriangleLists = new Uint32Array(buffer, offset, remainingU32s);
+
+  return {
+    tideLevels,
+    vertexPositions,
+    flowData,
+    indices,
+    vertexCount,
+    triangleCount,
+    gridCols,
+    gridRows,
+    gridMinX,
+    gridMinY,
+    gridCellWidth,
+    gridCellHeight,
+    gridCellHeaders,
+    gridTriangleLists,
+  };
+}


### PR DESCRIPTION
Precompute spatially-varying tidal currents offline using Finite Element
Method on an adaptive triangle mesh built from terrain contour polylines
via Constrained Delaunay Triangulation. Two orthogonal flow fields are
solved per tide level, enabling rotary tidal ellipses at runtime.

Rust pipeline: CDT mesh generation (spade), depth-weighted Laplacian FEM
solver (nalgebra-sparse Cholesky), spatial grid for O(1) lookup, binary
.tidemesh serialization.

TypeScript runtime: binary parser, GPU buffer packing, WGSL shader module
for barycentric interpolation + tide level blending, TidalResources
singleton entity, integration into water query shader and manager.

https://claude.ai/code/session_01NpEtuSytKfz4kKvnbPiVQW