### PR TITLE
Fix chaotic sail unfurling by resetting newly-activated cloth vertices

### DIFF
--- a/src/game/boat/sail/ClothSolver.ts
+++ b/src/game/boat/sail/ClothSolver.ts
@@ -252,6 +252,17 @@ export class ClothSolver {
     this.skipped[index] = skip ? 1 : 0;
   }
 
+  /** Reset a single vertex position and zero its velocity. */
+  resetVertex(index: number, x: number, y: number, z: number): void {
+    const i3 = index * 3;
+    this.positions[i3] = x;
+    this.positions[i3 + 1] = y;
+    this.positions[i3 + 2] = z;
+    this.prevPositions[i3] = x;
+    this.prevPositions[i3 + 1] = y;
+    this.prevPositions[i3 + 2] = z;
+  }
+
   /**
    * Snapshot solver state for transfer to a worker.
    * Returns copies of internal arrays for one-time transfer.

--- a/src/game/boat/sail/ClothSolverSync.ts
+++ b/src/game/boat/sail/ClothSolverSync.ts
@@ -24,6 +24,7 @@ export class ClothSolverSync implements ClothPositionReader {
   private readonly vertexV: Float64Array;
   private readonly furlMode: FurlMode;
   private readonly vertexActive: Uint8Array;
+  private readonly prevVertexActive: Uint8Array;
   private solved = false;
 
   // Reaction force accumulators
@@ -53,6 +54,7 @@ export class ClothSolverSync implements ClothPositionReader {
     this.vertexV = vertexV;
     this.furlMode = furlMode;
     this.vertexActive = new Uint8Array(solver.vertexCount);
+    this.prevVertexActive = new Uint8Array(solver.vertexCount);
   }
 
   hasNewResults(): boolean {
@@ -219,6 +221,27 @@ export class ClothSolverSync implements ClothPositionReader {
         active[i] = this.vertexU[i] >= wrapThreshold ? 1 : 0;
       }
     }
+
+    // Reset vertices that just transitioned from skipped to active (v-cutoff only).
+    // Skipped vertices don't get their positions updated, so they drift as the boat
+    // moves. Without this reset they enter the Verlet integrator at stale positions,
+    // causing explosive constraint corrections.
+    if (this.furlMode === "v-cutoff") {
+      for (let i = 0; i < vertexCount; i++) {
+        if (active[i] && !this.prevVertexActive[i]) {
+          const v = this.vertexV[i];
+          solver.resetVertex(
+            i,
+            tackX + v * (headX - tackX),
+            tackY + v * (headY - tackY),
+            tackZ + v * (headZ - tackZ),
+          );
+        }
+      }
+    }
+
+    // Save active state for next frame's transition detection
+    this.prevVertexActive.set(active);
 
     // Clear pins and skipped
     for (let i = 0; i < vertexCount; i++) {

--- a/src/game/boat/sail/ClothSolverSync.ts
+++ b/src/game/boat/sail/ClothSolverSync.ts
@@ -24,7 +24,6 @@ export class ClothSolverSync implements ClothPositionReader {
   private readonly vertexV: Float64Array;
   private readonly furlMode: FurlMode;
   private readonly vertexActive: Uint8Array;
-  private readonly prevVertexActive: Uint8Array;
   private solved = false;
 
   // Reaction force accumulators
@@ -54,7 +53,6 @@ export class ClothSolverSync implements ClothPositionReader {
     this.vertexV = vertexV;
     this.furlMode = furlMode;
     this.vertexActive = new Uint8Array(solver.vertexCount);
-    this.prevVertexActive = new Uint8Array(solver.vertexCount);
   }
 
   hasNewResults(): boolean {
@@ -222,36 +220,14 @@ export class ClothSolverSync implements ClothPositionReader {
       }
     }
 
-    // Reset vertices that just transitioned from skipped to active (v-cutoff only).
-    // Skipped vertices don't get their positions updated, so they drift as the boat
-    // moves. Without this reset they enter the Verlet integrator at stale positions,
-    // causing explosive constraint corrections.
-    if (this.furlMode === "v-cutoff") {
-      for (let i = 0; i < vertexCount; i++) {
-        if (active[i] && !this.prevVertexActive[i]) {
-          const v = this.vertexV[i];
-          solver.resetVertex(
-            i,
-            tackX + v * (headX - tackX),
-            tackY + v * (headY - tackY),
-            tackZ + v * (headZ - tackZ),
-          );
-        }
-      }
-    }
-
-    // Save active state for next frame's transition detection
-    this.prevVertexActive.set(active);
-
-    // Clear pins and skipped
+    // Clear pin states — we'll set them fresh each frame
     for (let i = 0; i < vertexCount; i++) {
       solver.setPinned(i, false);
-      solver.setSkipped(i, false);
     }
 
     // Pin active luff vertices
     for (const li of this.luffVertices) {
-      if (!active[li] && this.furlMode === "v-cutoff") continue;
+      if (!active[li]) continue;
       const v = this.vertexV[li];
       solver.setPinned(li, true);
       solver.setPinTarget(
@@ -262,23 +238,19 @@ export class ClothSolverSync implements ClothPositionReader {
       );
     }
 
-    if (this.furlMode === "v-cutoff") {
-      for (let i = 0; i < vertexCount; i++) {
-        if (!active[i]) solver.setSkipped(i, true);
-      }
-    } else {
-      // u-wrap: pin wrapped vertices to forestay
-      for (let i = 0; i < vertexCount; i++) {
-        if (!active[i]) {
-          const v = this.vertexV[i];
-          solver.setPinned(i, true);
-          solver.setPinTarget(
-            i,
-            tackX + v * (headX - tackX),
-            tackY + v * (headY - tackY),
-            tackZ + v * (headZ - tackZ),
-          );
-        }
+    // Pin all inactive vertices to the luff at their v-height. This keeps their
+    // positions current as the boat moves, so they enter the simulation smoothly
+    // when they become active (no stale-position explosions).
+    for (let i = 0; i < vertexCount; i++) {
+      if (!active[i]) {
+        const v = this.vertexV[i];
+        solver.setPinned(i, true);
+        solver.setPinTarget(
+          i,
+          tackX + v * (headX - tackX),
+          tackY + v * (headY - tackY),
+          tackZ + v * (headZ - tackZ),
+        );
       }
     }
 

--- a/src/game/boat/sail/cloth-worker.ts
+++ b/src/game/boat/sail/cloth-worker.ts
@@ -75,8 +75,6 @@ let vertexU: Float64Array;
 let vertexV: Float64Array;
 // Per-vertex active flag (reused each frame, allocated once)
 let vertexActive: Uint8Array;
-// Previous frame's active flags — used to detect skipped→active transitions
-let prevVertexActive: Uint8Array;
 
 self.onmessage = (e: MessageEvent<ClothWorkerMessage>) => {
   const msg = e.data;
@@ -94,7 +92,6 @@ self.onmessage = (e: MessageEvent<ClothWorkerMessage>) => {
     vertexU = msg.vertexU;
     vertexV = msg.vertexV;
     vertexActive = new Uint8Array(vertexCount);
-    prevVertexActive = new Uint8Array(vertexCount);
 
     // Reconstruct solver from snapshot
     solver = ClothSolver.fromSnapshot({
@@ -177,36 +174,14 @@ function updateFurlState(
     }
   }
 
-  // Reset vertices that just transitioned from skipped to active (v-cutoff only).
-  // Skipped vertices don't get their positions updated, so they drift as the boat
-  // moves. Without this reset they enter the Verlet integrator at stale positions,
-  // causing explosive constraint corrections.
-  if (furlMode === "v-cutoff") {
-    for (let i = 0; i < vertexCount; i++) {
-      if (vertexActive[i] && !prevVertexActive[i]) {
-        const v = vertexV[i];
-        solver.resetVertex(
-          i,
-          tackX + v * (headX - tackX),
-          tackY + v * (headY - tackY),
-          tackZ + v * (headZ - tackZ),
-        );
-      }
-    }
-  }
-
-  // Save active state for next frame's transition detection
-  prevVertexActive.set(vertexActive);
-
-  // Clear all pin and skip states — we'll set them fresh each frame
+  // Clear all pin states — we'll set them fresh each frame
   for (let i = 0; i < vertexCount; i++) {
     solver.setPinned(i, false);
-    solver.setSkipped(i, false);
   }
 
   // Pin all active luff vertices to the mast/forestay (lerp tack→head by v)
   for (const li of luffVertices) {
-    if (!vertexActive[li] && furlMode === "v-cutoff") continue;
+    if (!vertexActive[li]) continue;
     const v = vertexV[li];
     solver.setPinned(li, true);
     solver.setPinTarget(
@@ -217,26 +192,19 @@ function updateFurlState(
     );
   }
 
-  if (furlMode === "v-cutoff") {
-    // Skip all inactive vertices — they're inside the boom
-    for (let i = 0; i < vertexCount; i++) {
-      if (!vertexActive[i]) {
-        solver.setSkipped(i, true);
-      }
-    }
-  } else {
-    // u-wrap: pin wrapped (inactive) vertices to forestay at their v-height
-    for (let i = 0; i < vertexCount; i++) {
-      if (!vertexActive[i]) {
-        const v = vertexV[i];
-        solver.setPinned(i, true);
-        solver.setPinTarget(
-          i,
-          tackX + v * (headX - tackX),
-          tackY + v * (headY - tackY),
-          tackZ + v * (headZ - tackZ),
-        );
-      }
+  // Pin all inactive vertices to the luff at their v-height. This keeps their
+  // positions current as the boat moves, so they enter the simulation smoothly
+  // when they become active (no stale-position explosions).
+  for (let i = 0; i < vertexCount; i++) {
+    if (!vertexActive[i]) {
+      const v = vertexV[i];
+      solver.setPinned(i, true);
+      solver.setPinTarget(
+        i,
+        tackX + v * (headX - tackX),
+        tackY + v * (headY - tackY),
+        tackZ + v * (headZ - tackZ),
+      );
     }
   }
 

--- a/src/game/boat/sail/cloth-worker.ts
+++ b/src/game/boat/sail/cloth-worker.ts
@@ -75,6 +75,8 @@ let vertexU: Float64Array;
 let vertexV: Float64Array;
 // Per-vertex active flag (reused each frame, allocated once)
 let vertexActive: Uint8Array;
+// Previous frame's active flags — used to detect skipped→active transitions
+let prevVertexActive: Uint8Array;
 
 self.onmessage = (e: MessageEvent<ClothWorkerMessage>) => {
   const msg = e.data;
@@ -92,6 +94,7 @@ self.onmessage = (e: MessageEvent<ClothWorkerMessage>) => {
     vertexU = msg.vertexU;
     vertexV = msg.vertexV;
     vertexActive = new Uint8Array(vertexCount);
+    prevVertexActive = new Uint8Array(vertexCount);
 
     // Reconstruct solver from snapshot
     solver = ClothSolver.fromSnapshot({
@@ -173,6 +176,27 @@ function updateFurlState(
       vertexActive[i] = vertexU[i] >= wrapThreshold ? 1 : 0;
     }
   }
+
+  // Reset vertices that just transitioned from skipped to active (v-cutoff only).
+  // Skipped vertices don't get their positions updated, so they drift as the boat
+  // moves. Without this reset they enter the Verlet integrator at stale positions,
+  // causing explosive constraint corrections.
+  if (furlMode === "v-cutoff") {
+    for (let i = 0; i < vertexCount; i++) {
+      if (vertexActive[i] && !prevVertexActive[i]) {
+        const v = vertexV[i];
+        solver.resetVertex(
+          i,
+          tackX + v * (headX - tackX),
+          tackY + v * (headY - tackY),
+          tackZ + v * (headZ - tackZ),
+        );
+      }
+    }
+  }
+
+  // Save active state for next frame's transition detection
+  prevVertexActive.set(vertexActive);
 
   // Clear all pin and skip states — we'll set them fresh each frame
   for (let i = 0; i < vertexCount; i++) {


### PR DESCRIPTION
In v-cutoff (mainsail) furl mode, skipped vertices never have their
positions updated while excluded from simulation. When the boat moves
and hoistAmount increases, these vertices enter the Verlet integrator
at stale world-space positions — potentially many feet from adjacent
pinned luff vertices — causing explosive constraint corrections.

Now track per-vertex active state across frames and, when a vertex
transitions from skipped to active, reset it to its luff-interpolated
position (tack + v*(head-tack)) with zero velocity. Applied to both
the web worker and sync fallback solver paths.

https://claude.ai/code/session_01JrLS7ZXDjM1FbNxXZZQ5Nn