### PR TITLE
Add rope wrap constraint for hull crossings

### DIFF
--- a/src/core/physics/constraints/DeckContactConstraint.ts
+++ b/src/core/physics/constraints/DeckContactConstraint.ts
@@ -1,5 +1,10 @@
 import type { Body } from "../body/Body";
 import { PointToRigidEquation3D } from "../equations/PointToRigidEquation3D";
+import {
+  findLevelForZ,
+  findNearestEdge,
+  pointInPolygon,
+} from "../utils/HullBoundaryGeometry";
 import { Constraint, type ConstraintOptions } from "./Constraint";
 
 // ── Hull boundary data ─────────────────────────────────────────────
@@ -163,7 +168,7 @@ export class DeckContactConstraint extends Constraint {
         particle.position[1],
         particle.z,
       );
-      this.inside = this.pointInPolygon(deckLevel, lx, ly);
+      this.inside = pointInPolygon(deckLevel, lx, ly);
     } else {
       this.inside = true;
     }
@@ -191,7 +196,7 @@ export class DeckContactConstraint extends Constraint {
       return this;
     }
 
-    const insideDeckOutline = this.pointInPolygon(deckLevel, lx, ly);
+    const insideDeckOutline = pointInPolygon(deckLevel, lx, ly);
 
     // ── State transitions ──────────────────────────────────────────
     if (this.inside && !insideDeckOutline) {
@@ -298,14 +303,14 @@ export class DeckContactConstraint extends Constraint {
     }
 
     // Find the z-appropriate hull outline level
-    const zLevel = this.findLevelForZ(lz);
+    const zLevel = findLevelForZ(boundary, lz);
     if (!zLevel) {
       this.disableAll(normal, friction1, friction2);
       return;
     }
 
     // Find nearest hull edge at this z-level
-    const nearest = this.findNearestEdge(zLevel, lx, ly);
+    const nearest = findNearestEdge(zLevel, lx, ly);
     if (nearest.distSq > 25) {
       // > 5 ft from hull → disable
       this.disableAll(normal, friction1, friction2);
@@ -499,96 +504,6 @@ export class DeckContactConstraint extends Constraint {
     // Tangent 2: hull's local Y axis (starboard) in world space
     this.setShapeJacobian(friction2, R[1], R[4], R[7], rjX, rjY, rjZ);
     friction2.offset = 0;
-  }
-
-  // ── Geometry helpers ─────────────────────────────────────────────
-
-  /** Point-in-polygon test (ray-casting) on flat arrays. */
-  private pointInPolygon(
-    level: HullBoundaryLevel,
-    px: number,
-    py: number,
-  ): boolean {
-    const n = level.count;
-    const vx = level.vx;
-    const vy = level.vy;
-    let inside = false;
-    for (let i = 0, j = n - 1; i < n; j = i++) {
-      const yi = vy[i],
-        yj = vy[j];
-      if (
-        yi > py !== yj > py &&
-        px < ((vx[j] - vx[i]) * (py - yi)) / (yj - yi) + vx[i]
-      ) {
-        inside = !inside;
-      }
-    }
-    return inside;
-  }
-
-  /** Find the nearest point on the hull polygon boundary at a given z-level. */
-  private findNearestEdge(
-    level: HullBoundaryLevel,
-    px: number,
-    py: number,
-  ): { edgeIndex: number; cx: number; cy: number; distSq: number } {
-    const n = level.count;
-    const vx = level.vx;
-    const vy = level.vy;
-
-    let bestDistSq = Infinity;
-    let bestIdx = 0;
-    let bestCx = 0;
-    let bestCy = 0;
-
-    for (let i = 0; i < n; i++) {
-      const j = (i + 1) % n;
-      const ax = vx[i],
-        ay = vy[i];
-      const ex = vx[j] - ax;
-      const ey = vy[j] - ay;
-      const lenSq = ex * ex + ey * ey;
-
-      // Project point onto edge, clamped to [0, 1]
-      let t: number;
-      if (lenSq < 1e-16) {
-        t = 0;
-      } else {
-        t = ((px - ax) * ex + (py - ay) * ey) / lenSq;
-        if (t < 0) t = 0;
-        else if (t > 1) t = 1;
-      }
-
-      const cx = ax + t * ex;
-      const cy = ay + t * ey;
-      const dx = px - cx;
-      const dy = py - cy;
-      const dSq = dx * dx + dy * dy;
-
-      if (dSq < bestDistSq) {
-        bestDistSq = dSq;
-        bestIdx = i;
-        bestCx = cx;
-        bestCy = cy;
-      }
-    }
-
-    return { edgeIndex: bestIdx, cx: bestCx, cy: bestCy, distSq: bestDistSq };
-  }
-
-  /** Find the hull outline level at or just below the given z-height (conservative: narrower). */
-  private findLevelForZ(z: number): HullBoundaryLevel | null {
-    const levels = this.boundary.levels;
-    if (levels.length === 0) return null;
-
-    // Below everything → use bottom level
-    if (z <= levels[0].z) return levels[0];
-
-    // Walk up to find the level at or just below z
-    for (let i = levels.length - 1; i >= 0; i--) {
-      if (levels[i].z <= z) return levels[i];
-    }
-    return levels[0];
   }
 
   private disableAll(

--- a/src/core/physics/constraints/WrapConstraint3D.ts
+++ b/src/core/physics/constraints/WrapConstraint3D.ts
@@ -1,0 +1,236 @@
+/**
+ * 3-body rope "wrap" constraint for hull crossings.
+ *
+ * Models the situation where two adjacent rope particles end up on opposite
+ * sides of an infinitely-thin hull wall — typically because the boat moved
+ * and swept its hull past a stationary rope particle. The straight-line
+ * chain constraint between those two particles "cuts the corner" through
+ * the wall: the chord is shorter than the over-the-edge path, so the chain
+ * constraint sees slack that isn't really there and no tension transmits.
+ *
+ * This constraint sits *alongside* the regular chain distance constraint,
+ * adding the strictly tighter upper-limit
+ *
+ *     |A − peg| + |peg − B| ≤ totalLength
+ *
+ * only while a hull straddle is detected. The peg is recomputed each
+ * substep from the chord's intersection with the deck-level hull outline;
+ * it slides along the gunwale as the rope and hull move.
+ *
+ * Shape-wise this is the same as {@link PulleyConstraint3D} — a single
+ * {@link PulleyEquation} with an 18-component Jacobian. The differences are
+ * that (1) the "pulley anchor" on bodyC is recomputed each substep instead
+ * of being a fixed `localAnchorC`, (2) there is no ratchet or friction sub-
+ * equation (first pass), and (3) the equation is disabled as soon as the
+ * particles are back on the same side of the hull.
+ */
+
+import type { Body } from "../body/Body";
+import { DynamicBody } from "../body/DynamicBody";
+import { PulleyEquation } from "../equations/PulleyEquation";
+import { findChordHullCrossing } from "../utils/HullBoundaryGeometry";
+import { Constraint, type ConstraintOptions } from "./Constraint";
+import type {
+  DeckContactConstraint,
+  HullBoundaryData,
+} from "./DeckContactConstraint";
+
+export interface WrapConstraint3DOptions extends ConstraintOptions {
+  /** Max constraint force. Default MAX_VALUE. */
+  maxForce?: number;
+}
+
+export class WrapConstraint3D extends Constraint {
+  /** The hull body the rope is wrapping around (bodyC in PulleyEquation). */
+  readonly hullBody: Body;
+
+  /** Chain link length — the over-the-peg path may not exceed this. */
+  totalLength: number;
+
+  /** Max force magnitude (upper-limit only, so minForce = -maxForce). */
+  maxForce: number;
+
+  /** Current distance from particle A to the peg. */
+  distA: number = 0;
+  /** Current distance from the peg to particle B. */
+  distB: number = 0;
+  /** Current total path distance (distA + distB). */
+  position: number = 0;
+
+  private readonly sumEquation: PulleyEquation;
+  private readonly hullBoundary: HullBoundaryData;
+  private readonly deckContactA: DeckContactConstraint;
+  private readonly deckContactB: DeckContactConstraint;
+
+  constructor(
+    particleA: Body,
+    particleB: Body,
+    hullBody: Body,
+    hullBoundary: HullBoundaryData,
+    deckContactA: DeckContactConstraint,
+    deckContactB: DeckContactConstraint,
+    totalLength: number,
+    options: WrapConstraint3DOptions = {},
+  ) {
+    super(particleA, particleB, options);
+    this.hullBody = hullBody;
+    this.hullBoundary = hullBoundary;
+    this.deckContactA = deckContactA;
+    this.deckContactB = deckContactB;
+    this.totalLength = totalLength;
+    this.maxForce = options.maxForce ?? Number.MAX_VALUE;
+
+    if ((options.wakeUpBodies ?? true) && hullBody instanceof DynamicBody) {
+      hullBody.wakeUp();
+    }
+
+    // Sum equation: 3-body, constrains total path length. Upper-limit only.
+    this.sumEquation = new PulleyEquation(particleA, particleB, hullBody);
+    this.sumEquation.maxForce = 0;
+    this.sumEquation.minForce = -this.maxForce;
+    this.sumEquation.enabled = false;
+
+    const self = this;
+    this.sumEquation.computeGq = function () {
+      return self.position - self.totalLength;
+    };
+
+    this.equations = [this.sumEquation];
+  }
+
+  /** Set the max force for this constraint. */
+  setMaxForce(maxForce: number): void {
+    this.maxForce = maxForce;
+    this.sumEquation.minForce = -maxForce;
+  }
+
+  update(): this {
+    const eq = this.sumEquation;
+
+    // ── 1. Straddle check ────────────────────────────────────────────
+    // No straddle → no wrap. Cheap early-out; the chord constraint does
+    // its usual job on its own.
+    const aInside = this.deckContactA.isInside();
+    const bInside = this.deckContactB.isInside();
+    if (aInside === bInside) {
+      eq.enabled = false;
+      return this;
+    }
+
+    // ── 2. Compute peg from chord vs hull outline ────────────────────
+    // Particle world positions.
+    const particleA = this.bodyA;
+    const particleB = this.bodyB;
+    const ax = particleA.position[0];
+    const ay = particleA.position[1];
+    const az = particleA.z;
+    const bx = particleB.position[0];
+    const by = particleB.position[1];
+    const bz = particleB.z;
+
+    // Hull-local for the chord crossing test (2D at deck level).
+    const localA = this.hullBody.toLocalFrame3D(ax, ay, az);
+    const localB = this.hullBody.toLocalFrame3D(bx, by, bz);
+    const crossing = findChordHullCrossing(
+      this.hullBoundary,
+      localA[0],
+      localA[1],
+      aInside,
+      localB[0],
+      localB[1],
+    );
+    if (!crossing) {
+      eq.enabled = false;
+      return this;
+    }
+
+    // Lift the peg to world space.
+    const pegWorld = this.hullBody.toWorldFrame3D(
+      crossing.px,
+      crossing.py,
+      crossing.pz,
+    );
+    const px = pegWorld[0];
+    const py = pegWorld[1];
+    const pz = pegWorld[2];
+
+    // ── 3. Distances and unit directions ─────────────────────────────
+    const dAx = ax - px;
+    const dAy = ay - py;
+    const dAz = az - pz;
+    const dBx = bx - px;
+    const dBy = by - py;
+    const dBz = bz - pz;
+    this.distA = Math.sqrt(dAx * dAx + dAy * dAy + dAz * dAz);
+    this.distB = Math.sqrt(dBx * dBx + dBy * dBy + dBz * dBz);
+    this.position = this.distA + this.distB;
+
+    // ── 4. Enable only if the over-the-peg path is longer than the budget.
+    // Otherwise the chord constraint is already sufficient.
+    if (this.position <= this.totalLength) {
+      eq.enabled = false;
+      return this;
+    }
+
+    eq.enabled = true;
+    eq.maxForce = 0;
+    eq.minForce = -this.maxForce;
+
+    // Unit direction from peg toward A.
+    let nAx: number, nAy: number, nAz: number;
+    if (this.distA > 0.0001) {
+      const inv = 1 / this.distA;
+      nAx = dAx * inv;
+      nAy = dAy * inv;
+      nAz = dAz * inv;
+    } else {
+      nAx = 1;
+      nAy = 0;
+      nAz = 0;
+    }
+
+    // Unit direction from peg toward B.
+    let nBx: number, nBy: number, nBz: number;
+    if (this.distB > 0.0001) {
+      const inv = 1 / this.distB;
+      nBx = dBx * inv;
+      nBy = dBy * inv;
+      nBz = dBz * inv;
+    } else {
+      nBx = -1;
+      nBy = 0;
+      nBz = 0;
+    }
+
+    // ── 5. Lever arms ────────────────────────────────────────────────
+    // Particle anchors are the body centers, so rA = 0 and rB = 0 (the
+    // angular contributions vanish), but PulleyEquation still wants the
+    // fields filled. Use zeros for A/B, and the hull-center-to-peg vector
+    // for C.
+    const hull = this.hullBody;
+    const rCx = px - hull.position[0];
+    const rCy = py - hull.position[1];
+    const rCz = pz - hull.z;
+
+    // ── 6. Fill the 18-element Jacobian ──────────────────────────────
+    eq.setJacobian(
+      nAx,
+      nAy,
+      nAz,
+      nBx,
+      nBy,
+      nBz,
+      0,
+      0,
+      0, // rA: particle center = anchor
+      rCx,
+      rCy,
+      rCz,
+      0,
+      0,
+      0, // rB: particle center = anchor
+    );
+
+    return this;
+  }
+}

--- a/src/core/physics/utils/HullBoundaryGeometry.ts
+++ b/src/core/physics/utils/HullBoundaryGeometry.ts
@@ -1,0 +1,209 @@
+/**
+ * Shared 2D queries against pre-computed hull boundary outlines.
+ *
+ * These helpers were originally private to `DeckContactConstraint` and have
+ * been hoisted here so that other constraints (like the rope wrap constraint)
+ * can reuse them without duplicating the flat-array traversal math.
+ *
+ * All routines are zero-allocation and operate on the `HullBoundaryLevel`
+ * shape built by `buildBoundaryLevel()`.
+ */
+
+import type {
+  HullBoundaryData,
+  HullBoundaryLevel,
+} from "../constraints/DeckContactConstraint";
+
+/** Point-in-polygon test (ray-casting) on flat vertex arrays. */
+export function pointInPolygon(
+  level: HullBoundaryLevel,
+  px: number,
+  py: number,
+): boolean {
+  const n = level.count;
+  const vx = level.vx;
+  const vy = level.vy;
+  let inside = false;
+  for (let i = 0, j = n - 1; i < n; j = i++) {
+    const yi = vy[i];
+    const yj = vy[j];
+    if (
+      yi > py !== yj > py &&
+      px < ((vx[j] - vx[i]) * (py - yi)) / (yj - yi) + vx[i]
+    ) {
+      inside = !inside;
+    }
+  }
+  return inside;
+}
+
+/** Find the nearest point on the hull polygon boundary at a given z-level. */
+export function findNearestEdge(
+  level: HullBoundaryLevel,
+  px: number,
+  py: number,
+): { edgeIndex: number; cx: number; cy: number; distSq: number } {
+  const n = level.count;
+  const vx = level.vx;
+  const vy = level.vy;
+
+  let bestDistSq = Infinity;
+  let bestIdx = 0;
+  let bestCx = 0;
+  let bestCy = 0;
+
+  for (let i = 0; i < n; i++) {
+    const j = (i + 1) % n;
+    const ax = vx[i];
+    const ay = vy[i];
+    const ex = vx[j] - ax;
+    const ey = vy[j] - ay;
+    const lenSq = ex * ex + ey * ey;
+
+    // Project point onto edge, clamped to [0, 1]
+    let t: number;
+    if (lenSq < 1e-16) {
+      t = 0;
+    } else {
+      t = ((px - ax) * ex + (py - ay) * ey) / lenSq;
+      if (t < 0) t = 0;
+      else if (t > 1) t = 1;
+    }
+
+    const cx = ax + t * ex;
+    const cy = ay + t * ey;
+    const dx = px - cx;
+    const dy = py - cy;
+    const dSq = dx * dx + dy * dy;
+
+    if (dSq < bestDistSq) {
+      bestDistSq = dSq;
+      bestIdx = i;
+      bestCx = cx;
+      bestCy = cy;
+    }
+  }
+
+  return { edgeIndex: bestIdx, cx: bestCx, cy: bestCy, distSq: bestDistSq };
+}
+
+/**
+ * Find the hull outline level at or just below the given z-height
+ * (conservative: narrower).
+ */
+export function findLevelForZ(
+  boundary: HullBoundaryData,
+  z: number,
+): HullBoundaryLevel | null {
+  const levels = boundary.levels;
+  if (levels.length === 0) return null;
+
+  // Below everything → use bottom level
+  if (z <= levels[0].z) return levels[0];
+
+  // Walk down to find the level at or just below z
+  for (let i = levels.length - 1; i >= 0; i--) {
+    if (levels[i].z <= z) return levels[i];
+  }
+  return levels[0];
+}
+
+// ── Chord/hull intersection for the wrap peg ───────────────────────────────
+
+/** Result of `findChordHullCrossing` — a hull-local 3D point. */
+export interface ChordCrossingResult {
+  px: number;
+  py: number;
+  pz: number;
+}
+
+// Scratch object reused across calls — callers must read before the next call.
+const CROSSING_SCRATCH: ChordCrossingResult = { px: 0, py: 0, pz: 0 };
+
+/**
+ * Find the point where the chord between two hull-local points crosses the
+ * deck-level hull outline. Used by the rope wrap constraint to place the peg
+ * when adjacent rope particles end up on opposite sides of the gunwale.
+ *
+ * The chord is clipped against the topmost (deck-level) outline, which is
+ * the surface a rope drapes over when it hangs off the edge of the cockpit.
+ * If multiple edges are crossed, the crossing nearest the "outside" particle
+ * along the chord is returned — that is the edge the rope is physically
+ * wrapped around.
+ *
+ * Returns `null` if there is no crossing, or if the hull boundary has no
+ * deck-level outline yet. When the chord straddles the outline (one endpoint
+ * inside, one outside) there will always be at least one crossing for a
+ * closed polygon, so `null` is primarily a degenerate-geometry guard.
+ *
+ * @param aLocalX hull-local X of particle A
+ * @param aLocalY hull-local Y of particle A
+ * @param aInside whether particle A is inside the deck outline (for picking
+ *                the crossing closest to the *outside* particle)
+ * @param bLocalX hull-local X of particle B
+ * @param bLocalY hull-local Y of particle B
+ * @returns a mutated scratch point (valid until the next call), or `null`
+ */
+export function findChordHullCrossing(
+  boundary: HullBoundaryData,
+  aLocalX: number,
+  aLocalY: number,
+  aInside: boolean,
+  bLocalX: number,
+  bLocalY: number,
+): ChordCrossingResult | null {
+  const levels = boundary.levels;
+  if (levels.length === 0) return null;
+  const deckLevel = levels[levels.length - 1];
+
+  const n = deckLevel.count;
+  const vx = deckLevel.vx;
+  const vy = deckLevel.vy;
+
+  // Chord direction (A → B in hull-local XY).
+  const dx = bLocalX - aLocalX;
+  const dy = bLocalY - aLocalY;
+
+  // We want the crossing closest to whichever endpoint is *outside* the
+  // hull. If A is inside, outside = B (t → 1); otherwise outside = A (t → 0).
+  // Track the best t accordingly.
+  const preferLargeT = aInside;
+  let bestT = preferLargeT ? -Infinity : Infinity;
+  let bestX = 0;
+  let bestY = 0;
+  let found = false;
+
+  for (let i = 0; i < n; i++) {
+    const j = (i + 1) % n;
+    const ex = vx[j] - vx[i];
+    const ey = vy[j] - vy[i];
+
+    // Solve: aLocal + t*(b-a) = v_i + u*e,  with t,u ∈ [0,1].
+    // Cramer's rule on the 2x2 system:
+    //   [ dx  -ex ] [ t ]   [ vx[i] - aLocalX ]
+    //   [ dy  -ey ] [ u ] = [ vy[i] - aLocalY ]
+    const denom = dx * -ey - dy * -ex; // = -dx*ey + dy*ex
+    if (denom === 0) continue; // parallel
+
+    const rx = vx[i] - aLocalX;
+    const ry = vy[i] - aLocalY;
+    const t = (rx * -ey - ry * -ex) / denom;
+    if (t < 0 || t > 1) continue;
+    const u = (dx * ry - dy * rx) / denom;
+    if (u < 0 || u > 1) continue;
+
+    if (preferLargeT ? t > bestT : t < bestT) {
+      bestT = t;
+      bestX = aLocalX + t * dx;
+      bestY = aLocalY + t * dy;
+      found = true;
+    }
+  }
+
+  if (!found) return null;
+
+  CROSSING_SCRATCH.px = bestX;
+  CROSSING_SCRATCH.py = bestY;
+  CROSSING_SCRATCH.pz = boundary.deckHeight;
+  return CROSSING_SCRATCH;
+}

--- a/src/game/rope/Rope.ts
+++ b/src/game/rope/Rope.ts
@@ -14,7 +14,10 @@
 import { BaseEntity } from "../../core/entity/BaseEntity";
 import type { Body } from "../../core/physics/body/Body";
 import type { DynamicBody } from "../../core/physics/body/DynamicBody";
-import type { HullBoundaryData } from "../../core/physics/constraints/DeckContactConstraint";
+import type {
+  DeckContactConstraint,
+  HullBoundaryData,
+} from "../../core/physics/constraints/DeckContactConstraint";
 import { PointToRigidDistanceConstraint3D } from "../../core/physics/constraints/PointToRigidDistanceConstraint3D";
 import { V, V2d } from "../../core/Vector";
 import { CompatibleVector3, V3, V3d } from "../../core/Vector3";
@@ -249,6 +252,30 @@ export class Rope extends BaseEntity {
       : undefined;
 
     for (let i = 0; i < numParticles - 1; i++) {
+      // Wrap constraint config: pair up the deck-contact constraints of the
+      // two neighboring particles so the segment can cheaply tell whether
+      // this pair currently straddles the hull edge.
+      let wrapConfig:
+        | {
+            hullBody: Body;
+            hullBoundary: HullBoundaryData;
+            deckContactA: DeckContactConstraint;
+            deckContactB: DeckContactConstraint;
+          }
+        | undefined;
+      if (config.deckContact) {
+        const dcA = this.particleEntities[i].getDeckContact();
+        const dcB = this.particleEntities[i + 1].getDeckContact();
+        if (dcA && dcB) {
+          wrapConfig = {
+            hullBody: bodyB,
+            hullBoundary: config.deckContact.hullBoundary,
+            deckContactA: dcA,
+            deckContactB: dcB,
+          };
+        }
+      }
+
       const segment = new RopeSegment(
         this.particles[i],
         this.particles[i + 1],
@@ -263,6 +290,7 @@ export class Rope extends BaseEntity {
           solverOrder: 2 * (i + 1) + 1,
           internalFriction,
           drag: segmentDragConfig,
+          wrap: wrapConfig,
         },
       );
       this.addChild(segment);

--- a/src/game/rope/RopeParticle.ts
+++ b/src/game/rope/RopeParticle.ts
@@ -128,10 +128,19 @@ export class RopeParticle extends BaseEntity {
    * deck-contact constraint.
    */
   isInside(): boolean {
+    const constraint = this.getDeckContact();
+    return constraint != null ? constraint.isInside() : false;
+  }
+
+  /**
+   * The particle's {@link DeckContactConstraint}, or null if this particle
+   * has no deck contact configured. Used by {@link RopeSegment}'s wrap
+   * constraint, which needs the per-particle inside/outside flag each
+   * substep.
+   */
+  getDeckContact(): DeckContactConstraint | null {
     const constraint = this.constraints?.[0];
-    return constraint instanceof DeckContactConstraint
-      ? constraint.isInside()
-      : false;
+    return constraint instanceof DeckContactConstraint ? constraint : null;
   }
 
   private applyTerrainFloor(p: DynamicBody): void {

--- a/src/game/rope/RopeSegment.ts
+++ b/src/game/rope/RopeSegment.ts
@@ -11,8 +11,14 @@
 
 import { BaseEntity } from "../../core/entity/BaseEntity";
 import { on } from "../../core/entity/handler";
+import type { Body } from "../../core/physics/body/Body";
 import type { DynamicBody } from "../../core/physics/body/DynamicBody";
+import type {
+  DeckContactConstraint,
+  HullBoundaryData,
+} from "../../core/physics/constraints/DeckContactConstraint";
 import { ParticleDistanceConstraint3D } from "../../core/physics/constraints/ParticleDistanceConstraint3D";
+import { WrapConstraint3D } from "../../core/physics/constraints/WrapConstraint3D";
 import { V, V2d } from "../../core/Vector";
 import { LBF_TO_ENGINE, RHO_AIR, RHO_WATER } from "../physics-constants";
 import { WaterQuery } from "../world/water/WaterQuery";
@@ -41,6 +47,19 @@ export interface RopeSegmentConfig {
     cdNormal: number;
     /** Skin friction coefficient for axial flow (~0.02). */
     cdTangent: number;
+  };
+  /**
+   * Hull wrap constraint config. If present, the segment pre-creates a
+   * {@link WrapConstraint3D} alongside its chain constraint that activates
+   * only while the two particles straddle the hull — modelling the rope
+   * wrapping around the gunwale so tension transmits over the edge rather
+   * than through the wall.
+   */
+  wrap?: {
+    hullBody: Body;
+    hullBoundary: HullBoundaryData;
+    deckContactA: DeckContactConstraint;
+    deckContactB: DeckContactConstraint;
   };
 }
 
@@ -91,6 +110,29 @@ export class RopeSegment extends BaseEntity {
       eq.solverOrder = config.solverOrder;
     }
     this.constraints = [c];
+
+    // Wrap constraint: disabled by default, activates only while the two
+    // particles straddle the hull. Matches the chain constraint's stiffness
+    // and solver order so the wrap bite-down is consistent with the chord
+    // pull on this segment.
+    if (config.wrap) {
+      const wrap = new WrapConstraint3D(
+        particleA,
+        particleB,
+        config.wrap.hullBody,
+        config.wrap.hullBoundary,
+        config.wrap.deckContactA,
+        config.wrap.deckContactB,
+        config.length,
+        { collideConnected: true, wakeUpBodies: false },
+      );
+      for (const eq of wrap.equations) {
+        eq.stiffness = config.stiffness;
+        eq.relaxation = config.relaxation;
+        eq.solverOrder = config.solverOrder;
+      }
+      this.constraints.push(wrap);
+    }
 
     // Drag setup
     this.airDrag = config.drag?.airDrag ?? false;


### PR DESCRIPTION
When adjacent rope particles end up on opposite sides of the hull wall,
the chain distance constraint cuts the corner: the chord is shorter than
the over-the-edge path, so the chord sees slack and no tension transmits.
The rope droops through the hull and can't be retrieved.

This adds a 3-body WrapConstraint3D that sits alongside each segment's
chain constraint. When the two particles straddle the deck outline, the
constraint enforces |A-peg| + |peg-B| <= length with the peg recomputed
each substep from the chord's intersection with the hull. When there's
no straddle, the wrap equation is disabled and costs essentially nothing.

- Extract DeckContactConstraint's private geometry helpers into a shared
  HullBoundaryGeometry module and add findChordHullCrossing for the peg.
- WrapConstraint3D owns a single PulleyEquation (18-component Jacobian)
  and follows the same disabled-by-default pattern PulleyConstraint3D
  uses for its ratchet/friction sub-equations.
- Pre-create one wrap per RopeSegment when deck contact is configured;
  RopeParticle exposes getDeckContact() so segments can read the
  per-particle inside/outside flag each substep.

Endpoint chain links (A->P0, Pn-1->B) still use a 2-body shape and are
not wrapped in this pass; that's a deferred follow-up.