### PR TITLE
Stations: replace free-walk with Z/X auto-walk

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ This file provides guidance to Claude Code when working with this 2D sailing gam
 - **Wind** (`Wind.ts`, `WindParticles.ts`) - Global wind field with procedural variation using simplex noise
 - **Water** (`water/`) - Gerstner wave simulation with currents and wake effects
 - **World** (`world/`) - GPU-accelerated world state queries (terrain height, water surface, wind velocity) via WebGPU compute shaders with double-buffered readback and zero-allocation results. See [`src/game/world/CLAUDE.md`](src/game/world/CLAUDE.md) for architecture details.
-- **Controls** - Station-based: the player walks a sailor character between stations on the boat (Helm, Mast, Bow) using WASD. Each station exposes different controls (e.g. A/D for rudder at the Helm, W/S for hoist at the Mast). See [`src/game/boat/sailor/CLAUDE.md`](src/game/boat/sailor/CLAUDE.md) for details.
+- **Controls** - Station-based: the player is always at a station on the boat (Helm, Mast, Bow). **Z** and **X** cycle to the previous/next station; the sailor auto-walks the deck between them. Each station exposes different controls (e.g. A/D for rudder at the Helm, W/S for hoist at the Mast). See [`src/game/boat/sailor/CLAUDE.md`](src/game/boat/sailor/CLAUDE.md) for details.
 
 ### Terrain Editor (`src/editor/`)
 

--- a/src/game/boat/PlayerBoatController.ts
+++ b/src/game/boat/PlayerBoatController.ts
@@ -7,20 +7,15 @@ import { Port } from "../port/Port";
 import { PortMenu } from "../port/PortMenu";
 import { Boat } from "./Boat";
 import { findBowPoint } from "./Hull";
-import {
-  SAILOR_RUN_SPEED,
-  SAILOR_WALK_SPEED,
-  type Sailor,
-} from "./sailor/Sailor";
 import type { StationDef } from "./sailor/StationConfig";
 
 const DOCK_RANGE = 30; // feet — max distance to dock from bow
 
 /**
  * Maps player input to boat actions. Controls are gated by the sailor's
- * current station: when walking, WASD drives the sailor and all boat
- * controls are inert; when at a station, WASD/QE drive that station's
- * bound controls.
+ * current station: while in transit between stations, all boat controls
+ * are inert; when at a station, WASD/QE drive that station's bound
+ * controls. Z and X cycle to the previous/next station.
  */
 export class PlayerBoatController extends BaseEntity {
   tickLayer = "input" as const;
@@ -52,47 +47,17 @@ export class PlayerBoatController extends BaseEntity {
     // Not at a bail station — ensure bailing is off
     this.boat.bilge.setBailing(false);
 
-    // Sailor is walking — WASD drives walking, boat controls inert
-    if (sailor.state.kind === "walking") {
-      this.onTickWalking(sailor);
+    // Sailor is in transit — boat controls inert, rudder floats
+    if (sailor.state.kind !== "atStation") {
+      this.boat.rudder.setSteer(0);
+      this.game.io.setSteeringWheelForceFeedback(0);
+      this.boat.anchor.idle();
       return;
     }
 
     // Sailor is at a station — dispatch controls based on station bindings
     const station = sailor.getCurrentStation()!;
     this.onTickAtStation(station, dt);
-  }
-
-  // ── Walking mode ────────────────────────────────────────────────
-
-  private onTickWalking(sailor: Sailor): void {
-    const io = this.game.io;
-
-    // Release the rudder — it floats when unattended
-    this.boat.rudder.setSteer(0);
-    io.setSteeringWheelForceFeedback(0);
-
-    // Idle the anchor (no input)
-    this.boat.anchor.idle();
-
-    // WASD → walk velocity, interpreted in camera space (W = up on screen).
-    // Screen direction is rotated into hull-local coords via the camera and
-    // hull angles. The deck friction equations' Jacobian sign convention
-    // makes a positive `relativeVelocity` push the sailor along the
-    // -tangent direction, so we negate at the end.
-    const running = io.isKeyDown("ShiftLeft") || io.isKeyDown("ShiftRight");
-    const speed = running ? SAILOR_RUN_SPEED : SAILOR_WALK_SPEED;
-    let sx = 0;
-    let sy = 0;
-    if (io.isKeyDown("KeyW")) sy -= 1;
-    if (io.isKeyDown("KeyS")) sy += 1;
-    if (io.isKeyDown("KeyA")) sx -= 1;
-    if (io.isKeyDown("KeyD")) sx += 1;
-
-    const hullAngle = this.boat.hull.getAngle();
-    const cameraAngle = this.game.camera.angle;
-    const local = V(sx, sy).irotate(-cameraAngle - hullAngle);
-    sailor.setWalkVelocity(-local.x * speed, -local.y * speed, speed);
   }
 
   // ── Station mode ────────────────────────────────────────────────
@@ -347,14 +312,18 @@ export class PlayerBoatController extends BaseEntity {
 
     const sailor = this.boat.sailor;
 
+    // Z / X cycle stations from any state (in-transit retargets).
+    if (key === "KeyZ") {
+      sailor.goToNeighborStation(-1);
+      return;
+    }
+    if (key === "KeyX") {
+      sailor.goToNeighborStation(+1);
+      return;
+    }
+
     if (sailor.state.kind === "atStation") {
       const station = sailor.getCurrentStation()!;
-
-      // F at any station → leave and start walking
-      if (key === "KeyF") {
-        sailor.beginWalking();
-        return;
-      }
 
       // M at a station with mooring action → dock toggle
       if (key === "KeyM" && station.actions?.includes("mooring")) {
@@ -366,12 +335,6 @@ export class PlayerBoatController extends BaseEntity {
             this.boat.mooring.moorTo(nearbyPort);
           }
         }
-        return;
-      }
-    } else {
-      // Walking — F snaps to a nearby station (auto-snap also runs each tick).
-      if (key === "KeyF") {
-        sailor.snapToNearbyStation();
         return;
       }
     }

--- a/src/game/boat/sailor/CLAUDE.md
+++ b/src/game/boat/sailor/CLAUDE.md
@@ -1,16 +1,12 @@
 # Sailor & Station System (`src/game/boat/sailor/`)
 
-The player controls a visible sailor character that walks between **stations** on the boat. Each station exposes a different subset of controls, so sailing the boat requires physically moving to the right position. This creates meaningful tradeoffs (you can't steer while walking to the bow to drop anchor).
+The player controls a visible sailor character that occupies one of several **stations** on the boat. Each station exposes a different subset of controls, so sailing the boat requires moving to the right position. The player is always at a station; **Z** and **X** cycle to the previous/next station and the sailor auto-walks the deck between them. The walk takes time, which preserves the meaningful tradeoff (you can't steer while moving to the bow to drop the anchor) without forcing the player to drive the walk by hand.
 
 ## How it works
 
-### Modal input
-
-Controls are **modal**: when the sailor is at a station, WASD/QE operate that station's controls. When walking between stations, WASD moves the sailor and no sailing controls work. The rudder floats when unattended (no steering torque applied).
-
 ### Stations
 
-Stations are defined per-boat in `BoatConfig.stations` (with `BoatConfig.initialStationId` naming the starting station). Each station maps input axes to boat controls:
+Stations are defined per-boat in `BoatConfig.stations` (an ordered array; `BoatConfig.initialStationId` names the starting station). Each station maps input axes to boat controls:
 
 - **steerAxis** (A/D) -- e.g. `"rudder"` at the Helm
 - **primaryAxis** (W/S) -- e.g. `"mainsheet"` at Helm, `"mainHoist"` at Mast, `"jibHoistFurl"` at Bow
@@ -25,35 +21,48 @@ Default station layout (defined in `BaseBoat`, inherited by all boats):
 | Mast    | --        | mainHoist    | --            | bail            |
 | Bow     | --        | jibHoistFurl | --            | anchor, mooring |
 
-### Walking
+### State machine
 
-- Press **F** at any station to leave and start walking. Unbound WASD keys do nothing at a station (e.g. A/D at the Mast, where only W/S is bound, have no effect — F is the only way to leave).
-- WASD drives the sailor in **camera-space** directions: W = up on screen, S = down, A = left, D = right. When `rotateWithBoat` is on this matches hull-local forward/back/port/starboard; with a fixed camera the sailor walks toward the pressed screen direction regardless of hull heading.
-- To enter a station, walk within `SAILOR_SNAP_RADIUS` of it and press **F**. The sailor does not auto-snap — entering is always an explicit action.
+The sailor has two states:
 
-### Walking physics
+- `atStation { stationId }` -- pinned to the station via a 3-axis position lock (`stationWeld`). Station controls are live.
+- `transit { targetStationId }` -- walking toward the destination. Station controls are inert; the rudder floats and the anchor idles.
 
-The sailor is a dynamic point-mass-3D body (`createPointMass3D({ motion: "dynamic", … })`) with a `Particle` shape, constrained to the deck via `DeckContactConstraint` with two extensions:
+### Z / X cycling
 
-1. **`preventFallOff`** -- blocks the inside-to-outside state transition so the sailor can never leave the deck. When the sailor reaches the hull boundary, the constraint applies an inward wall force instead of transitioning to outside mode.
+- **Z** = previous station, **X** = next station, in the order defined by `BoatConfig.stations`.
+- Clamped at the array ends (no wrap-around).
+- Pressing Z/X mid-transit retargets without stopping — the sailor pivots toward the new destination.
 
-2. **Motorized friction** (`targetVelocityX`/`targetVelocityY`) -- the friction equations normally drive relative tangential velocity to zero. These fields set `relativeVelocity` on the friction equations so the solver drives toward the walk speed instead of zero. Walking is literally "set the friction setpoint."
+### Auto-walk
 
-The sailor's mass (`SAILOR_MASS` in `Sailor.ts`) affects boat balance through the deck constraint's reaction forces -- the same mechanism that lets ropes on deck transfer load to the hull.
+In `transit`, the sailor's tick handler drives the deck's friction motor (`SailorDeckConstraint.targetVelocityX/Y`) straight toward the target station's hull-local position at `SAILOR_WALK_SPEED`. When the sailor crosses within `SAILOR_SNAP_RADIUS` of the target, `snapToStation()` re-enables the station weld (with a `beginWeldRamp()` slide to avoid an impulse) and the state flips back to `atStation`.
+
+Path planning is straight-line. The deck is convex on current hulls so this is sufficient; if a future hull layout has obstructions between stations a per-config waypoint table would be the next step, but it is not currently needed.
+
+### Deck physics
+
+The sailor is a dynamic point-mass-3D body (`createPointMass3D({ motion: "dynamic", … })`) with a `Particle` shape, constrained to the deck via `SailorDeckConstraint` (a `DeckContactConstraint` extended for the sailor) with two extras:
+
+1. **`preventFallOff`** -- blocks the inside-to-outside state transition so the sailor can never leave the deck. At the hull boundary the constraint applies an inward wall force instead of transitioning to outside mode.
+
+2. **Motorized friction** (`targetVelocityX`/`targetVelocityY`) -- the friction equations normally drive relative tangential velocity to zero. These fields set `relativeVelocity` on the friction equations so the solver drives toward the walk velocity instead of zero. Walking is literally "set the friction setpoint."
+
+The sailor's mass (`SAILOR_MASS` in `Sailor.ts`) affects boat balance through the deck constraint's reaction forces -- the same mechanism that lets ropes on deck transfer load to the hull. As the sailor walks fore/aft during transit, the hull pitches in response; this is preserved from the previous free-walk model.
 
 ## Files
 
 - **`StationConfig.ts`** -- `StationDef`, `AxisControl`, `ActionControl` types
-- **`Sailor.ts`** -- entity with physics body, deck constraint, state machine (`atStation` | `walking`), rendering (orange circle). Also exports `SAILOR_MASS`, `SAILOR_WALK_SPEED`, `SAILOR_RUN_SPEED`, `SAILOR_SNAP_RADIUS` constants (not boat-dependent).
-- **`StationHUD.tsx`** -- ReactEntity HUD showing current station name, key bindings, and walking indicator
+- **`Sailor.ts`** -- entity with physics body, deck constraint, state machine (`atStation` | `transit`), rendering (orange circle). Also exports `SAILOR_MASS`, `SAILOR_WALK_SPEED`, `SAILOR_SNAP_RADIUS` constants (not boat-dependent).
+- **`StationHUD.tsx`** -- ReactEntity HUD showing current station name (or transit destination), key bindings, and Z/X cycle hints
 
 ## Integration points
 
-- **`BoatConfig.stations`** / **`BoatConfig.initialStationId`** -- required fields on every boat config. The boat defines where stations are and what each controls; per-sailor constants (mass, walk/run speed, snap radius) live in `Sailor.ts`.
+- **`BoatConfig.stations`** / **`BoatConfig.initialStationId`** -- required fields on every boat config. The boat defines where stations are and what each controls; per-sailor constants (mass, walk speed, snap radius) live in `Sailor.ts`.
 - **`Boat.sailor`** -- the `Sailor` entity, always constructed. Added as a child of `Boat` after `BoatRenderer` for correct draw ordering.
-- **`PlayerBoatController`** -- reads `boat.sailor.getCurrentStation()` to gate input. Two modes: walking (WASD drives sailor, boat controls inert) and at-station (dispatches to bound controls).
-- **`DeckContactConstraint`** (`src/core/physics/constraints/`) -- the base constraint used by ropes, extended with `preventFallOff` and `targetVelocityX/Y` for the sailor.
+- **`PlayerBoatController`** -- handles `KeyZ`/`KeyX` → `sailor.goToNeighborStation(±1)`. Each tick, when the sailor is not at a station, releases the rudder and idles the anchor; otherwise dispatches to the bound controls.
+- **`DeckContactConstraint`** (`src/core/physics/constraints/`) -- base constraint used by ropes; the sailor uses the `SailorDeckConstraint` subclass with `preventFallOff` and the friction motor.
 - **`GameController`** -- adds `StationHUD` alongside other HUDs on game start.
-- **`SaveFile.boat.sailor`** -- persists `stationId` and hull-local `position`. Save version 3.
+- **`SaveFile.boat.sailor`** -- persists `stationId` only. Save version 4. Mid-transit saves persist the target as the station id (sailor effectively snaps to the destination on reload).
 - **`configScale.ts`** -- scales station positions with hull geometry (`sx`, `sy`).
-- **`CustomEvent.ts`** -- `sailorEnteredStation` and `sailorLeftStation` events.
+- **`CustomEvent.ts`** -- `sailorEnteredStation` (fired on snap) and `sailorLeftStation` (fired when transit begins).

--- a/src/game/boat/sailor/Sailor.ts
+++ b/src/game/boat/sailor/Sailor.ts
@@ -13,11 +13,9 @@ import type { StationDef } from "./StationConfig";
 /** Sailor mass in lbs — average adult. Affects boat balance via deck constraint reaction. */
 export const SAILOR_MASS = 170;
 
-/** Walking speed in ft/s — cautious walking on a moving boat. */
+/** Walking speed in ft/s while transiting between stations. */
 export const SAILOR_WALK_SPEED = 6;
-/** Running speed in ft/s — hustling when Shift is held. */
-export const SAILOR_RUN_SPEED = 12;
-/** Proximity radius (ft) for snapping to a station on arrival. */
+/** Proximity radius (ft) at which the sailor snaps onto the target station. */
 export const SAILOR_SNAP_RADIUS = 2.5;
 
 const SAILOR_RADIUS = 0.8; // ft — visual radius of the orange circle
@@ -54,7 +52,7 @@ const SAILOR_WELD_RAMP_DURATION = 0.3;
 
 export type SailorState =
   | { kind: "atStation"; stationId: string }
-  | { kind: "walking" };
+  | { kind: "transit"; targetStationId: string };
 
 export class Sailor extends BaseEntity {
   layer = "boat" as const;
@@ -63,7 +61,7 @@ export class Sailor extends BaseEntity {
   private readonly stations: readonly StationDef[];
   private readonly hullBody: Body;
   private readonly deckConstraint: SailorDeckConstraint;
-  /** 3-axis position lock to the current station. Disabled while walking. */
+  /** 3-axis position lock to the current station. Disabled while in transit. */
   private readonly stationWeld: PointToRigidLockConstraint3D;
   private readonly deckHeight: number;
 
@@ -134,7 +132,7 @@ export class Sailor extends BaseEntity {
     this.deckConstraint.fixedFrictionForce = sailorWeight * SAILOR_FRICTION;
 
     // 3-axis position lock that holds the sailor at a station's hull-local
-    // anchor while stationed. Disabled while walking. The per-axis maxForce
+    // anchor while stationed. Disabled while in transit. The per-axis maxForce
     // cap bounds activation impulses and limits how hard the weld can yank
     // the hull.
     this.stationWeld = new PointToRigidLockConstraint3D(this.body, hullBody, {
@@ -167,7 +165,7 @@ export class Sailor extends BaseEntity {
     return this._state;
   }
 
-  /** The current station, or null if walking. */
+  /** The current station, or null if in transit. */
   getCurrentStation(): StationDef | null {
     if (this._state.kind === "atStation") {
       return this.getStation(this._state.stationId);
@@ -180,33 +178,44 @@ export class Sailor extends BaseEntity {
     return this._state.kind === "atStation" && this._state.stationId === id;
   }
 
-  /** Leave the current station and begin walking. */
-  beginWalking(): void {
+  /**
+   * Begin (or retarget) an auto-walk to the named station. If already at
+   * that station, no-op. If currently in transit to a different station,
+   * the target switches and the sailor turns toward it without stopping.
+   */
+  goToStation(id: string): void {
+    if (this._state.kind === "atStation" && this._state.stationId === id) {
+      return;
+    }
+    // Validate up front so callers fail fast.
+    this.getStation(id);
+
     if (this._state.kind === "atStation") {
-      const prevStation = this._state.stationId;
-      this._state = { kind: "walking" };
+      const prevStationId = this._state.stationId;
       this.deckConstraint.disabled = false;
       this.stationWeld.disabled = true;
-      this.game.dispatch("sailorLeftStation", { stationId: prevStation });
+      this._state = { kind: "transit", targetStationId: id };
+      this.game.dispatch("sailorLeftStation", { stationId: prevStationId });
+    } else {
+      // Already in transit — just retarget.
+      this._state = { kind: "transit", targetStationId: id };
     }
   }
 
   /**
-   * Set the walk velocity in hull-local coordinates (ft/s), clamped to
-   * `maxSpeed` by magnitude. Only has effect while walking.
+   * Step to the previous (-1) or next (+1) station in the boat's station
+   * order. Clamped at the ends — no wrap-around.
    */
-  setWalkVelocity(localX: number, localY: number, maxSpeed: number): void {
-    if (this._state.kind !== "walking") return;
-
-    const mag = Math.sqrt(localX * localX + localY * localY);
-    if (mag > maxSpeed) {
-      const scale = maxSpeed / mag;
-      localX *= scale;
-      localY *= scale;
-    }
-
-    this.deckConstraint.targetVelocityX = localX;
-    this.deckConstraint.targetVelocityY = localY;
+  goToNeighborStation(delta: 1 | -1): void {
+    const currentId =
+      this._state.kind === "atStation"
+        ? this._state.stationId
+        : this._state.targetStationId;
+    const idx = this.stations.findIndex((s) => s.id === currentId);
+    if (idx < 0) return;
+    const nextIdx = idx + delta;
+    if (nextIdx < 0 || nextIdx >= this.stations.length) return;
+    this.goToStation(this.stations[nextIdx].id);
   }
 
   // ── Tick ─────────────────────────────────────────────────────────
@@ -215,13 +224,36 @@ export class Sailor extends BaseEntity {
   onTick({ dt }: GameEventMap["tick"]): void {
     // Gravity always acts on the sailor body. When stationed, the 3-axis
     // station weld resists gravity and transfers the reaction to the hull
-    // at the station anchor. When walking, the deck constraint handles it.
+    // at the station anchor. In transit, the deck constraint handles it.
     this.body.applyForce3D(0, 0, -SAILOR_GRAVITY * this.body.mass, 0, 0, 0);
     if (this._state.kind === "atStation") {
       this.deckConstraint.targetVelocityX = 0;
       this.deckConstraint.targetVelocityY = 0;
       this.advanceWeldRamp(dt);
+    } else {
+      this.tickTransit();
     }
+  }
+
+  /**
+   * Drive the deck-friction motor straight at the target station each
+   * tick. On arrival within SAILOR_SNAP_RADIUS, snap onto the station.
+   */
+  private tickTransit(): void {
+    if (this._state.kind !== "transit") return;
+    const target = this.getStation(this._state.targetStationId);
+    const [lx, ly] = this.getLocalPosition();
+    const dx = target.position[0] - lx;
+    const dy = target.position[1] - ly;
+    const dist2 = dx * dx + dy * dy;
+    if (dist2 < SAILOR_SNAP_RADIUS * SAILOR_SNAP_RADIUS) {
+      this.snapToStation(target);
+      return;
+    }
+    const dist = Math.sqrt(dist2);
+    const scale = SAILOR_WALK_SPEED / dist;
+    this.deckConstraint.targetVelocityX = dx * scale;
+    this.deckConstraint.targetVelocityY = dy * scale;
   }
 
   private advanceWeldRamp(dt: number): void {
@@ -273,27 +305,8 @@ export class Sailor extends BaseEntity {
     }
   }
 
-  /** Return the station within snapRadius of the sailor, or null. */
-  findNearbyStation(): StationDef | null {
-    const [lx, ly] = this.getLocalPosition();
-    const r2 = SAILOR_SNAP_RADIUS * SAILOR_SNAP_RADIUS;
-    for (const station of this.stations) {
-      const dx = lx - station.position[0];
-      const dy = ly - station.position[1];
-      if (dx * dx + dy * dy < r2) return station;
-    }
-    return null;
-  }
-
-  /** Snap to a nearby station if one is in range. Does nothing otherwise. */
-  snapToNearbyStation(): void {
-    if (this._state.kind !== "walking") return;
-    const near = this.findNearbyStation();
-    if (near) this.snapToStation(near);
-  }
-
   private snapToStation(station: StationDef): void {
-    // Switch from walking to the station weld. No position/velocity
+    // Switch from transit motor to the station weld. No position/velocity
     // teleport — the ramped weld slides the anchor from the sailor's
     // current spot to the station, dragging them along smoothly.
     this.deckConstraint.targetVelocityX = 0;
@@ -346,45 +359,30 @@ export class Sailor extends BaseEntity {
   }
 
   /**
-   * Restore sailor state from a save file.
-   * If stationId is non-null, snaps to that station.
-   * Otherwise, places the sailor at the given hull-local position in walking mode.
+   * Restore sailor state from a save file. Snaps the sailor to the named
+   * station with no pull-in animation. Throws if the station is unknown
+   * (callers should validate / migrate before calling).
    */
-  restoreState(stationId: string | null, position: [number, number]): void {
-    if (stationId) {
-      const station = this.stations.find((s) => s.id === stationId);
-      if (station) {
-        const worldPos = this.stationWorldPosition(station);
-        this.body.position.set(worldPos);
-        this.body.velocity.set(0, 0);
-        this.body.zVelocity = 0;
-        this.deckConstraint.disabled = true;
-        this.stationWeld.localAnchorB.set(
-          station.position[0],
-          station.position[1],
-          this.deckHeight + SAILOR_RADIUS,
-        );
-        this.stationWeld.disabled = false;
-        // Load fully pinned — no pull-in animation on a fresh game.
-        this._weldRampT = 1;
-        this._weldRampStart.set(this.stationWeld.localAnchorB);
-        this._weldRampTarget.set(this.stationWeld.localAnchorB);
-        for (const eq of this.stationWeld.equations) {
-          eq.warmLambda = 0;
-          eq.multiplier = 0;
-        }
-        this._state = { kind: "atStation", stationId };
-        return;
-      }
-    }
-
-    // Walking or unknown station — place at position
-    const [wx, wy] = this.hullBody.toWorldFrame3D(position[0], position[1], 0);
-    this.body.position.set(wx, wy);
+  restoreState(stationId: string): void {
+    const station = this.getStation(stationId);
+    const worldPos = this.stationWorldPosition(station);
+    this.body.position.set(worldPos);
     this.body.velocity.set(0, 0);
     this.body.zVelocity = 0;
-    this.deckConstraint.disabled = false;
-    this.stationWeld.disabled = true;
-    this._state = { kind: "walking" };
+    this.deckConstraint.disabled = true;
+    this.stationWeld.localAnchorB.set(
+      station.position[0],
+      station.position[1],
+      this.deckHeight + SAILOR_RADIUS,
+    );
+    this.stationWeld.disabled = false;
+    this._weldRampT = 1;
+    this._weldRampStart.set(this.stationWeld.localAnchorB);
+    this._weldRampTarget.set(this.stationWeld.localAnchorB);
+    for (const eq of this.stationWeld.equations) {
+      eq.warmLambda = 0;
+      eq.multiplier = 0;
+    }
+    this._state = { kind: "atStation", stationId };
   }
 }

--- a/src/game/boat/sailor/StationHUD.tsx
+++ b/src/game/boat/sailor/StationHUD.tsx
@@ -20,8 +20,8 @@ const AXIS_KEYS: Record<"steer" | "primary" | "secondary", string> = {
 };
 
 /**
- * Always-visible HUD showing the sailor's current station and
- * available controls, or a walking indicator when between stations.
+ * Always-visible HUD showing the sailor's current station and available
+ * controls, or a transit indicator while moving between stations.
  */
 export class StationHUD extends ReactEntity {
   constructor() {
@@ -31,7 +31,7 @@ export class StationHUD extends ReactEntity {
   private renderContent() {
     const boat = this.game?.entities.getById("boat") as Boat | undefined;
     const sailor = boat?.sailor;
-    if (!sailor) return null;
+    if (!boat || !sailor) return null;
 
     return (
       <div
@@ -49,25 +49,20 @@ export class StationHUD extends ReactEntity {
           lineHeight: "1.5",
         }}
       >
-        {sailor.state.kind === "walking"
-          ? this.renderWalking()
-          : this.renderStation(sailor)}
+        {sailor.state.kind === "transit"
+          ? this.renderTransit(boat, sailor)
+          : this.renderStation(boat, sailor)}
       </div>
     );
   }
 
-  private renderWalking() {
-    const boat = this.game?.entities.getById("boat") as Boat | undefined;
-    const sailor = boat?.sailor;
-    const nearStation = sailor?.findNearbyStation() ?? null;
-
-    const bindings: Array<{ keys: string; label: string }> = [
-      { keys: "WASD", label: "Walk" },
-      { keys: "Shift", label: "Run" },
-    ];
-    if (nearStation) {
-      bindings.push({ keys: "F", label: `Enter ${nearStation.name}` });
-    }
+  private renderTransit(boat: Boat, sailor: Sailor) {
+    const state = sailor.state;
+    if (state.kind !== "transit") return null;
+    const target = boat.config.stations.find(
+      (s) => s.id === state.targetStationId,
+    );
+    if (!target) return null;
 
     return (
       <div>
@@ -79,14 +74,14 @@ export class StationHUD extends ReactEntity {
             color: "#ff8800",
           }}
         >
-          Walking
+          → {target.name}
         </div>
-        {this.renderBindingList(bindings)}
+        {this.renderBindingList(this.stationCycleBindings(boat, sailor))}
       </div>
     );
   }
 
-  private renderStation(sailor: Sailor) {
+  private renderStation(boat: Boat, sailor: Sailor) {
     const station = sailor.getCurrentStation();
     if (!station) return null;
 
@@ -102,12 +97,12 @@ export class StationHUD extends ReactEntity {
         >
           {station.name}
         </div>
-        {this.renderBindings(station)}
+        {this.renderBindings(boat, sailor, station)}
       </div>
     );
   }
 
-  private renderBindings(station: StationDef) {
+  private renderBindings(boat: Boat, sailor: Sailor, station: StationDef) {
     const bindings: Array<{ keys: string; label: string }> = [];
 
     if (station.steerAxis) {
@@ -138,9 +133,31 @@ export class StationHUD extends ReactEntity {
     if (station.actions?.includes("bail")) {
       bindings.push({ keys: "B", label: "Bail" });
     }
-    bindings.push({ keys: "F", label: "Leave Station" });
+    bindings.push(...this.stationCycleBindings(boat, sailor));
 
     return this.renderBindingList(bindings);
+  }
+
+  /** Z/X bindings labelled with the neighbor station's name; hidden at endpoints. */
+  private stationCycleBindings(
+    boat: Boat,
+    sailor: Sailor,
+  ): Array<{ keys: string; label: string }> {
+    const stations = boat.config.stations;
+    const state = sailor.state;
+    const currentId =
+      state.kind === "atStation" ? state.stationId : state.targetStationId;
+    const idx = stations.findIndex((s) => s.id === currentId);
+    if (idx < 0) return [];
+
+    const out: Array<{ keys: string; label: string }> = [];
+    if (idx > 0) {
+      out.push({ keys: "Z", label: `Go to ${stations[idx - 1].name}` });
+    }
+    if (idx < stations.length - 1) {
+      out.push({ keys: "X", label: `Go to ${stations[idx + 1].name}` });
+    }
+    return out;
   }
 
   private renderBindingList(bindings: Array<{ keys: string; label: string }>) {

--- a/src/game/persistence/SaveDeserializer.ts
+++ b/src/game/persistence/SaveDeserializer.ts
@@ -26,8 +26,5 @@ export function applySaveData(game: Game, save: SaveFile): void {
   boat.bilge.waterVolume = boatState.bilgeWater;
 
   // Restore sailor state
-  boat.sailor.restoreState(
-    boatState.sailor.stationId,
-    boatState.sailor.position,
-  );
+  boat.sailor.restoreState(boatState.sailor.stationId);
 }

--- a/src/game/persistence/SaveFile.ts
+++ b/src/game/persistence/SaveFile.ts
@@ -1,4 +1,4 @@
-export const CURRENT_SAVE_VERSION = 3;
+export const CURRENT_SAVE_VERSION = 4;
 
 export interface SaveFile {
   // Meta
@@ -22,10 +22,9 @@ export interface SaveFile {
       sail: number;
     };
     bilgeWater: number;
-    /** Sailor state: station id if at a station, or hull-local position if walking. */
+    /** Station the sailor is at (or in transit to — saves the destination). */
     sailor: {
-      stationId: string | null;
-      position: [number, number];
+      stationId: string;
     };
   };
 

--- a/src/game/persistence/SaveMigrations.ts
+++ b/src/game/persistence/SaveMigrations.ts
@@ -47,6 +47,23 @@ const MIGRATIONS: Migration[] = [
     }
     return data;
   },
+  // v3 -> v4: Sailor is always at a station — drop walking position, and
+  // recover walking-state saves by snapping to the helm.
+  (data) => {
+    const boat = data.boat as Record<string, unknown> | undefined;
+    if (!boat) return data;
+    const sailor = boat.sailor as Record<string, unknown> | undefined;
+    if (!sailor) {
+      boat.sailor = { stationId: "helm" };
+      return data;
+    }
+    const stationId =
+      typeof sailor.stationId === "string" && sailor.stationId.length > 0
+        ? sailor.stationId
+        : "helm";
+    boat.sailor = { stationId };
+    return data;
+  },
 ];
 
 /**

--- a/src/game/persistence/SaveSerializer.ts
+++ b/src/game/persistence/SaveSerializer.ts
@@ -48,11 +48,14 @@ export function collectSaveData(
       },
       bilgeWater: boat.bilge.waterVolume,
       sailor: {
+        // In-transit saves persist the destination — the sailor effectively
+        // teleports to the target on reload, which is acceptable since
+        // transits are short and the alternative (replaying the walk) adds
+        // complexity for no gameplay benefit.
         stationId:
           boat.sailor.state.kind === "atStation"
             ? boat.sailor.state.stationId
-            : null,
-        position: boat.sailor.getLocalPosition(),
+            : boat.sailor.state.targetStationId,
       },
     },
 


### PR DESCRIPTION
## Summary

- Replaces the free-walk-with-WASD station system with **Z/X cycling**: the player is always at a station, Z/X step to the previous/next station, and the sailor auto-walks the deck between them.
- Driven by playtester feedback that leaving a station, walking, and pressing F to enter another felt cumbersome and confusing rather than tactical.
- The "can't steer while moving to the bow" tradeoff is preserved by the walk's time cost — station controls go inert in transit, the rudder floats, and the sailor's mass still shifts the hull as they walk.

## Implementation notes

- **Sailor.ts**: state machine becomes `atStation` | `transit { targetStationId }`. New API `goToStation(id)` / `goToNeighborStation(±1)` (clamped, retargets mid-transit). `tickTransit()` drives the existing `SailorDeckConstraint.targetVelocityX/Y` straight at the destination at `SAILOR_WALK_SPEED`; on arrival within `SAILOR_SNAP_RADIUS`, reuses `snapToStation()` (and its existing weld-ramp slide) for a clean handoff. Dropped public walk API and `SAILOR_RUN_SPEED`.
- **PlayerBoatController.ts**: removed `onTickWalking`; non-`atStation` ticks just release the rudder/anchor. `KeyZ`/`KeyX` map to `goToNeighborStation(∓1)` from any state. F handler removed.
- **StationHUD.tsx**: transit header shows `→ {target.name}`; station view lists `Z — Go to {prev}` / `X — Go to {next}`, hidden at array endpoints.
- **SaveFile** bumped v3 → v4. Sailor shape simplified to `{ stationId }`. Mid-transit serializes the destination (snaps on reload). v3 migration recovers walking-state saves by snapping to the helm.
- Path planning is straight-line; deck is convex on current hulls. If a future hull blocks straight paths, a per-config waypoint table is the next step.

## Test plan

- [ ] `npm run tsgo` clean
- [ ] `npm test` passes (4 specs)
- [ ] Fresh game starts at Helm; X walks to Mast, X again to Bow, X at Bow no-ops, Z walks back
- [ ] Mid-transit X retargets without an awkward stop
- [ ] Heel the boat hard, then transit Helm → Bow — visible weight-shift and roll behavior unchanged from the old free-walk
- [ ] Drop anchor at Bow, immediately Z back to Helm — feel the time cost still gates "can't steer while moving"
- [ ] Save mid-transit → reload → sailor at destination
- [ ] Load a v3 walking-state save (if any) — sailor placed at helm

🤖 Generated with [Claude Code](https://claude.com/claude-code)